### PR TITLE
Reduce sound buffer size in order to decrease sound latency.

### DIFF
--- a/uae4all_gp2x_0.7.2a/src/custom.cpp
+++ b/uae4all_gp2x_0.7.2a/src/custom.cpp
@@ -3520,8 +3520,6 @@ void customreset (void)
     new_beamcon0 = mainMenu_ntsc ? 0 : 0x20;
     init_hz ();
     
-    audio_reset ();
-    
     init_sprites ();
     
     init_hardware_frame ();

--- a/uae4all_gp2x_0.7.2a/src/include/audio.h
+++ b/uae4all_gp2x_0.7.2a/src/include/audio.h
@@ -13,7 +13,7 @@
 #endif
 
 #ifdef NO_THREADS
-#define PRE_SNDBUFFER_LEN (960)
+#define PRE_SNDBUFFER_LEN (256)
 #else
 #define PRE_SNDBUFFER_LEN (1024)
 #endif


### PR DESCRIPTION
This reduces the sound latency to a point where it is not really noticeable.  I have tested this on my iPhone 5 and my iPad Air 2 with a few games and also octamed.

I think the Amiga emulators I have used previously make this a user-configurable value ("sound buffer size").  I don't know if it makes sense to make this user configurable for iAmiga since the set of hardware iAmiga can run on is limited... probably not very important right now.
