### PR TITLE
1.1.0b1 drivestate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.pbxproj -crlf -diff -merge

--- a/Classes/DiskDriveService.h
+++ b/Classes/DiskDriveService.h
@@ -1,13 +1,39 @@
+//  Created by Simon Toens on 19.06.15
 //
-//  DIskDriveService.h
-//  iUAE
+//  iUAE is free software: you may copy, redistribute
+//  and/or modify it under the terms of the GNU General Public License as
+//  published by the Free Software Foundation, either version 2 of the
+//  License, or (at your option) any later version.
 //
-//  Created by Simon Toens on 6/19/15.
+//  This file is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  General Public License for more details.
 //
-//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 #import <Foundation/Foundation.h>
 
+/**
+ * The disk drive service handles interactions with the disk drives.
+ */
 @interface DiskDriveService : NSObject
+
+/**
+ * Returns the adf path for the specified drive (df[0], df[1] ...), nil if no disk is inserted in the specified drive.
+ */
+- (NSString *)getInsertedDiskForDrive:(int)driveNumber;
+
+/**
+ * Inserts the specified adf into the specified drive (df[0], df[1] ...).
+ */
+- (void)insertDisk:(NSString *)adfPath intoDrive:(int)driveNumber;
+
+/**
+ * Inserts the specified adfs into the drives corresponding to the adfs' positions in the array: adf at position 0 -> df0, adf at position 1 -> df1 ...
+ */
+- (void)insertDisks:(NSArray *)adfPaths;
 
 @end

--- a/Classes/DiskDriveService.h
+++ b/Classes/DiskDriveService.h
@@ -1,0 +1,13 @@
+//
+//  DIskDriveService.h
+//  iUAE
+//
+//  Created by Simon Toens on 6/19/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface DiskDriveService : NSObject
+
+@end

--- a/Classes/DiskDriveService.mm
+++ b/Classes/DiskDriveService.mm
@@ -1,13 +1,62 @@
+//  Created by Simon Toens on 19.06.15
 //
-//  DIskDriveService.m
-//  iUAE
+//  iUAE is free software: you may copy, redistribute
+//  and/or modify it under the terms of the GNU General Public License as
+//  published by the Free Software Foundation, either version 2 of the
+//  License, or (at your option) any later version.
 //
-//  Created by Simon Toens on 6/19/15.
+//  This file is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  General Public License for more details.
 //
-//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+#import "uae.h"
+#import "sysconfig.h"
+#import "sysdeps.h"
+#import "options.h"
 
 #import "DiskDriveService.h"
 
-@implementation DIskDriveService
+@implementation DiskDriveService
+
+- (NSString *)getInsertedDiskForDrive:(int)driveNumber {
+    NSAssert(driveNumber >= 0 && driveNumber <= NUM_DRIVES, @"Bad drive number");
+    NSString *adfPath = [NSString stringWithCString:changed_df[driveNumber] encoding:[NSString defaultCStringEncoding]];
+    return [adfPath length] == 0 ? nil : adfPath;
+}
+
+- (void)insertDisk:(NSString *)adfPath intoDrive:(int)driveNumber {
+    NSAssert(driveNumber >= 0 && driveNumber <= NUM_DRIVES, @"Bad drive number");
+    [adfPath getCString:changed_df[driveNumber] maxLength:256 encoding:[NSString defaultCStringEncoding]];
+    real_changed_df[driveNumber] = 1;
+}
+
+- (void)insertDisks:(NSArray *)adfPaths {
+    for (int driveNumber = 0; driveNumber < [adfPaths count]; driveNumber++)
+    {
+        if (driveNumber < NUM_DRIVES)
+        {
+            NSString *adfPath = [adfPaths objectAtIndex:driveNumber];
+            if ([adfPath length] == 0) {
+                continue; // placeholder item
+            }
+            if ([[NSFileManager defaultManager] fileExistsAtPath:adfPath isDirectory:NULL]) {
+                // it is possible that the stored adf path is no longer valid - this often happens
+                // during debugging.  If that's the case, don't even attempt to insert the floppy
+                [self insertDisk:adfPath intoDrive:driveNumber];
+            } else {
+                NSLog(@"Adf does not exist: %@", adfPath);
+            }
+        }
+        else
+        {
+            break;
+        }
+    }
+}
 
 @end

--- a/Classes/DiskDriveService.mm
+++ b/Classes/DiskDriveService.mm
@@ -1,0 +1,13 @@
+//
+//  DIskDriveService.m
+//  iUAE
+//
+//  Created by Simon Toens on 6/19/15.
+//
+//
+
+#import "DiskDriveService.h"
+
+@implementation DIskDriveService
+
+@end

--- a/Classes/DiskDriveService.mm
+++ b/Classes/DiskDriveService.mm
@@ -49,7 +49,7 @@
                 // during debugging.  If that's the case, don't even attempt to insert the floppy
                 [self insertDisk:adfPath intoDrive:driveNumber];
             } else {
-                NSLog(@"Adf does not exist: %@", adfPath);
+                NSLog(@"adf does not exist: %@", adfPath);
             }
         }
         else

--- a/Classes/SettingsDisplayController.m
+++ b/Classes/SettingsDisplayController.m
@@ -13,10 +13,6 @@ extern int mainMenu_showStatus;
 extern int mainMenu_ntsc;
 extern int mainMenu_stretchscreen;
 
-@interface SettingsDisplayController ()
-
-@end
-
 @implementation SettingsDisplayController {
     Settings *settings;
 }
@@ -30,37 +26,28 @@ extern int mainMenu_stretchscreen;
     self.edgesForExtendedLayout = UIRectEdgeNone;
     
     settings = [[Settings alloc] init];
-
-
 }
 
 - (void)viewWillAppear:(BOOL)animated {
-
     [settings initializeSettings];
-    [_ntsc setOn:[settings boolForKey:@"_ntsc"]];
-    [_showstatus setOn:[settings boolForKey:@"_showstatus"]];
-    [_stretchscreen setOn:[settings boolForKey:@"_stretchscreen"]];
-
+    [_ntsc setOn:settings.ntsc];
+    [_showstatus setOn:settings.showStatus];
+    [_stretchscreen setOn:settings.stretchScreen];
 }
 
 - (void)toggleNTSC:(id)sender {
-    [settings setBool:_ntsc.isOn forKey:@"_ntsc"];
+    settings.ntsc = _ntsc.isOn;
     mainMenu_ntsc = _ntsc.isOn;
 }
 
 - (void)toggleShowstatus:(id)sender {
-    [settings setBool:_showstatus.isOn forKey:@"_showstatus"];
+    settings.showStatus = _showstatus.isOn;
     mainMenu_showStatus = _showstatus.isOn;
 }
 
 - (void)toggleStretchscreen:(id)sender {
-    [settings setBool:_stretchscreen.isOn forKey:@"_stretchscreen"];
+    settings.stretchScreen = _stretchscreen.isOn;
     mainMenu_stretchscreen = _stretchscreen.isOn;
-}
-
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
 }
 
 - (void)dealloc

--- a/Classes/SettingsGeneralController.m
+++ b/Classes/SettingsGeneralController.m
@@ -36,6 +36,15 @@
 }
 
 - (void)viewWillAppear:(BOOL)animated {
+    [self setupFloppyLabels];
+    [settings initializeSettings];
+    if([settings stringForKey:@"configurationname"])
+    {
+        [_configurationname setText:[settings stringForKey:@"configurationname"]];
+    }
+}
+
+-(void)setupFloppyLabels {
     NSString *df0title = @"Empty";
     NSString *df1title = @"Empty";
     
@@ -50,13 +59,6 @@
     
     [_df0 setText:df0title];
     [_df1 setText:df1title];
-    
-    [settings initializeSettings];
-    
-    if([settings stringForKey:@"configurationname"])
-    {
-        [_configurationname setText:[settings stringForKey:@"configurationname"]];
-    }
 }
 
 - (IBAction)toggleAutoloadconfig:(id)sender {

--- a/Classes/SettingsGeneralController.m
+++ b/Classes/SettingsGeneralController.m
@@ -100,6 +100,7 @@
     }
     [mutableFloppyPaths replaceObjectAtIndex:driveNumber withObject:adfPath];
     settings.insertedFloppies = mutableFloppyPaths;
+    [settings setFloppyConfiguration:adfPath];
     [diskDriveService insertDisk:adfPath intoDrive:driveNumber];
 }
 

--- a/Classes/SettingsGeneralController.m
+++ b/Classes/SettingsGeneralController.m
@@ -27,54 +27,27 @@
 
 @implementation SettingsGeneralController {
     Settings *settings;
-    NSMutableArray *Filepath;
     bool autoloadconfig;
 }
 
-static NSMutableArray *Filename;
-
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
     settings = [[Settings alloc] init];
-    Filepath = [[settings arrayForKey:@"insertedfloppies"] mutableCopy];
-    
-    autoloadconfig = [settings boolForKey:@"autoloadconfig"];
-    [_swautoloadconfig setOn:autoloadconfig animated:TRUE];
-    
-    if(!Filepath)
-    {
-        Filepath = [[NSMutableArray alloc] init];
-        [Filepath addObject:[NSMutableString new]];
-        [Filepath addObject:[NSMutableString new]];
-    }
-    
-    if(!Filename)
-    {
-        
-        Filename = [[NSMutableArray alloc] init];
-        
-        for(int i=0;i<2;i++) // should use NUM_DRIVES instead of hardcoding
-        {
-            NSString *curadf = [Filepath objectAtIndex:i];
-            
-            if(curadf)
-            {
-                [Filename addObject:[curadf lastPathComponent]];
-            }
-            else
-            {
-                [Filename addObject:[NSMutableString new]];
-            }
-        }
-    }
 }
 
 - (void)viewWillAppear:(BOOL)animated {
+    NSString *df0title = @"Empty";
+    NSString *df1title = @"Empty";
     
-    NSString *df0title = [[Filename objectAtIndex:0] length] == 0 ? @"Empty" : [Filename objectAtIndex:0];
-    NSString *df1title = [[Filename objectAtIndex:1] length] == 0 ? @"Empty" : [Filename objectAtIndex:1];
-        
+    NSArray *floppyPaths = [settings arrayForKey:@"insertedfloppies"];
+    
+    if ([floppyPaths count] >= 1) {
+        df0title = [[floppyPaths objectAtIndex:0] lastPathComponent];
+        if ([floppyPaths count] > 1) {
+            df1title = [[floppyPaths objectAtIndex:1] lastPathComponent];
+        }
+    }
+    
     [_df0 setText:df0title];
     [_df1 setText:df1title];
     
@@ -84,10 +57,6 @@ static NSMutableArray *Filename;
     {
         [_configurationname setText:[settings stringForKey:@"configurationname"]];
     }
-}
-
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
 }
 
 - (IBAction)toggleAutoloadconfig:(id)sender {
@@ -117,12 +86,9 @@ static NSMutableArray *Filename;
 - (void)didSelectROM:(EMUFileInfo *)fileInfo withContext:(UIButton*)sender {
     NSString *path = [fileInfo path];
     int df = sender.tag;
-    
-    [Filepath replaceObjectAtIndex:df withObject:path];
-    [settings setObject:Filepath forKey:@"insertedfloppies"];
-    
-    [Filename replaceObjectAtIndex:df withObject:[NSMutableString stringWithString:[fileInfo fileName]]];
-    
+    NSMutableArray *floppyPaths = [[[settings arrayForKey:@"insertedfloppies"] mutableCopy] autorelease];
+    [floppyPaths replaceObjectAtIndex:df withObject:path];
+    [settings setObject:floppyPaths forKey:@"insertedfloppies"];
 }
 
 - (NSString *)getfirstoption {
@@ -145,7 +111,7 @@ static NSMutableArray *Filename;
 }
 
 - (void)didDeleteConfiguration {
-    NSMutableArray *configurations = [[settings arrayForKey:@"configurations"] mutableCopy];
+    NSMutableArray *configurations = [[[settings arrayForKey:@"configurations"] mutableCopy] autorelease];
     
     if(![configurations indexOfObject:[_configurationname text]])
     {
@@ -155,9 +121,9 @@ static NSMutableArray *Filename;
 
 - (void)dealloc
 {
+    [settings release];
     [_df0 release];
     [_df1 release];
-    [Filepath release];
     [_configurationname release];
     [_cellconfiguration release];
     [_emulatorScreenshot release];

--- a/Classes/SettingsGeneralController.m
+++ b/Classes/SettingsGeneralController.m
@@ -18,16 +18,19 @@
 //along with this program; if not, write to the Free Software
 //Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
+#import "DiskDriveService.h"
 #import "SettingsGeneralController.h"
 #import "Settings.h"
 #import "StateManagementController.h"
 
 @implementation SettingsGeneralController {
+    DiskDriveService *diskDriveService;
     Settings *settings;
 }
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    diskDriveService = [[DiskDriveService alloc] init];
     settings = [[Settings alloc] init];
 }
 
@@ -43,10 +46,10 @@
 }
 
 - (void)setupFloppyLabels {
-    NSString *df0AdfPath = [settings getInsertedFloppyForDrive:0];
+    NSString *df0AdfPath = [diskDriveService getInsertedDiskForDrive:0];
     [_df0 setText:df0AdfPath ? [df0AdfPath lastPathComponent] : @"Empty"];
     
-    NSString *df1AdfPath = [settings getInsertedFloppyForDrive:1];
+    NSString *df1AdfPath = [diskDriveService getInsertedDiskForDrive:1];
     [_df1 setText:df1AdfPath ? [df1AdfPath lastPathComponent] : @"Empty"];
 }
 
@@ -97,7 +100,7 @@
     }
     [mutableFloppyPaths replaceObjectAtIndex:driveNumber withObject:adfPath];
     settings.insertedFloppies = mutableFloppyPaths;
-    [settings insertFloppy:adfPath intoDrive:driveNumber];
+    [diskDriveService insertDisk:adfPath intoDrive:driveNumber];
 }
 
 - (NSString *)getfirstoption {
@@ -128,8 +131,8 @@
     }
 }
 
-- (void)dealloc
-{
+- (void)dealloc {
+    [diskDriveService release];
     [settings release];
     [_df0 release];
     [_df1 release];

--- a/Classes/SettingsGeneralController.m
+++ b/Classes/SettingsGeneralController.m
@@ -51,19 +51,18 @@
 }
 
 - (void)setupConfigurationName {
-    if([settings stringForKey:@"configurationname"])
+    if(settings.configurationName)
     {
-        [_configurationname setText:[settings stringForKey:@"configurationname"]];
+        [_configurationname setText:settings.configurationName];
     }
 }
 
 - (void)setupAutoloadConfigSwitch {
-    [_swautoloadconfig setOn:[settings boolForKey:@"autoloadconfig"]];
+    [_swautoloadconfig setOn:settings.autoloadConfig];
 }
 
 - (IBAction)toggleAutoloadconfig:(id)sender {
-    BOOL autoloadconfig = ![settings boolForKey:@"autoloadconfig"];
-    [settings setBool:autoloadconfig forKey:@"autoloadconfig"];
+    settings.autoloadConfig = !settings.autoloadConfig;
 }
 
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
@@ -89,7 +88,7 @@
 - (void)didSelectROM:(EMUFileInfo *)fileInfo withContext:(UIButton*)sender {
     NSString *adfPath = [fileInfo path];
     int driveNumber = sender.tag;
-    NSArray *floppyPaths = [settings arrayForKey:@"insertedfloppies"];
+    NSArray *floppyPaths = settings.insertedFloppies;
     NSMutableArray *mutableFloppyPaths = floppyPaths ? [[floppyPaths mutableCopy] autorelease] : [[[NSMutableArray alloc] init] autorelease];
     while ([mutableFloppyPaths count] <= driveNumber)
     {
@@ -97,7 +96,7 @@
         [mutableFloppyPaths addObject:@""];
     }
     [mutableFloppyPaths replaceObjectAtIndex:driveNumber withObject:adfPath];
-    [settings setObject:mutableFloppyPaths forKey:@"insertedfloppies"];
+    settings.insertedFloppies = mutableFloppyPaths;
     [settings insertFloppy:adfPath intoDrive:driveNumber];
 }
 
@@ -115,13 +114,13 @@
     return FALSE;
 }
 
-- (void)didSelectConfiguration:(NSString *)configurationname {
-    [_configurationname setText:configurationname];
-    [settings setObject:configurationname forKey:@"configurationname"];
+- (void)didSelectConfiguration:(NSString *)configurationName {
+    [_configurationname setText:configurationName];
+    settings.configurationName = configurationName;
 }
 
 - (void)didDeleteConfiguration {
-    NSMutableArray *configurations = [[[settings arrayForKey:@"configurations"] mutableCopy] autorelease];
+    NSMutableArray *configurations = [[settings.configurations mutableCopy] autorelease];
     
     if(![configurations indexOfObject:[_configurationname text]])
     {

--- a/Classes/SettingsGeneralController.m
+++ b/Classes/SettingsGeneralController.m
@@ -45,20 +45,11 @@
 }
 
 -(void)setupFloppyLabels {
-    NSString *df0title = @"Empty";
-    NSString *df1title = @"Empty";
+    NSString *df0AdfPath = [settings getInsertedFloppyForDrive:0];
+    [_df0 setText:df0AdfPath ? [df0AdfPath lastPathComponent] : @"Empty"];
     
-    NSArray *floppyPaths = [settings arrayForKey:@"insertedfloppies"];
-    
-    if ([floppyPaths count] >= 1) {
-        df0title = [[floppyPaths objectAtIndex:0] lastPathComponent];
-        if ([floppyPaths count] > 1) {
-            df1title = [[floppyPaths objectAtIndex:1] lastPathComponent];
-        }
-    }
-    
-    [_df0 setText:df0title];
-    [_df1 setText:df1title];
+    NSString *df1AdfPath = [settings getInsertedFloppyForDrive:1];
+    [_df1 setText:df1AdfPath ? [df0AdfPath lastPathComponent] : @"Empty"];
 }
 
 - (IBAction)toggleAutoloadconfig:(id)sender {
@@ -86,11 +77,12 @@
 }
 
 - (void)didSelectROM:(EMUFileInfo *)fileInfo withContext:(UIButton*)sender {
-    NSString *path = [fileInfo path];
-    int df = sender.tag;
+    NSString *adfPath = [fileInfo path];
+    int driveNumber = sender.tag;
     NSMutableArray *floppyPaths = [[[settings arrayForKey:@"insertedfloppies"] mutableCopy] autorelease];
-    [floppyPaths replaceObjectAtIndex:df withObject:path];
+    [floppyPaths replaceObjectAtIndex:driveNumber withObject:adfPath];
     [settings setObject:floppyPaths forKey:@"insertedfloppies"];
+    [settings insertFloppy:adfPath intoDrive:driveNumber];
 }
 
 - (NSString *)getfirstoption {

--- a/Classes/StateFileManager.m
+++ b/Classes/StateFileManager.m
@@ -17,10 +17,10 @@
 #import "State.h"
 #import "StateFileManager.h"
 
-static NSString *kStatesDirectoryName = @"states";      // top level directory under Documents where all state information goes
-static NSString *kStateImagesDirectoryName = @"images"; // sub directory that stores the screenshot associated with a saved state
-static NSString *kStateFileExtension = @".asf";
-static NSString *kStateFileImageExtension = @".jpg";
+static NSString *const kStatesDirectoryName = @"states";      // top level directory under Documents where all state information goes
+static NSString *const kStateImagesDirectoryName = @"images"; // sub directory that stores the screenshot associated with a saved state
+static NSString *const kStateFileExtension = @".asf";
+static NSString *const kStateFileImageExtension = @".jpg";
 
 @implementation StateFileManager {
     @private

--- a/SelectConfigurationViewController.m
+++ b/SelectConfigurationViewController.m
@@ -143,14 +143,15 @@
     NSMutableArray *configurationsforsave = [configurations mutableCopy];
     [configurationsforsave removeObjectAtIndex:0]; //General or None is no real Configuration just a placeholder
 
-    [settings setObject:configurationsforsave forKey:@"configurations"];
+    settings.configurations = configurationsforsave;
     
     for (EMUFileInfo* f in files) {
         
         /*Associated Configuration File*/
         NSString *settingstring = [NSString stringWithFormat:@"cnf%@", [f fileName]];
         NSString *configurationfile = [settings stringForKey:settingstring] ? [settings stringForKey:settingstring] : [NSString stringWithFormat:@""];
-        if([configurationfile isEqualToString:configdeleted]) {
+        if([configurationfile isEqualToString:configdeleted])
+        {
             if(self.delegate)
             {
                 [self.delegate didDeleteConfiguration];

--- a/Storyboard.storyboard
+++ b/Storyboard.storyboard
@@ -379,20 +379,16 @@
                                                         <action selector="toggleAutoloadconfig:" destination="fDF-e7-E6W" eventType="touchUpInside" id="fFU-5L-qpc"/>
                                                     </connections>
                                                 </switch>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zBa-9T-6h3">
-                                                    <rect key="frame" x="20" y="7" width="1016" height="30"/>
-                                                    <state key="normal" title="Autoload Config">
-                                                        <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                                    </state>
-                                                </button>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Autoload Config" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c5D-FK-SMD">
+                                                    <rect key="frame" x="17" y="11" width="128" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="8pu-T2-h7e" firstAttribute="centerY" secondItem="Mme-e3-H3P" secondAttribute="centerY" id="2d3-kv-qse"/>
-                                                <constraint firstItem="zBa-9T-6h3" firstAttribute="bottom" secondItem="8pu-T2-h7e" secondAttribute="bottom" id="Bwy-ue-bow"/>
-                                                <constraint firstItem="zBa-9T-6h3" firstAttribute="leading" secondItem="Mme-e3-H3P" secondAttribute="leadingMargin" constant="12" id="XJl-6h-90x"/>
                                                 <constraint firstItem="8pu-T2-h7e" firstAttribute="trailing" secondItem="Mme-e3-H3P" secondAttribute="trailingMargin" id="jJq-sj-Ad8"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="zBa-9T-6h3" secondAttribute="trailing" constant="-20" id="jsz-J9-6RW"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -487,7 +483,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5VK-Vz-1xK" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2208.75" y="2384.1549295774648"/>
+            <point key="canvasLocation" x="2208" y="2384"/>
         </scene>
         <!--Joystick-->
         <scene sceneID="9Ze-AO-zNo">

--- a/TargetSpecific/SingleView/SingleWindowAppDelegate.mm
+++ b/TargetSpecific/SingleView/SingleWindowAppDelegate.mm
@@ -47,14 +47,7 @@
     //Get some view Specific properties
     UINavigationController *navigationcontroller = self.window.rootViewController;
     mainController = navigationcontroller.topViewController;
-    
-    // load disks into df0: and df1:
-    NSString *path = [[NSBundle mainBundle] pathForResource:@"DISK1" ofType:@"ADF"];
-    [path getCString:prefs_df[0] maxLength:256 encoding:[NSString defaultCStringEncoding]];
-    fprintf(stdout, ">>>>>>> %s\n", prefs_df[0]);
-    path = [[NSBundle mainBundle] pathForResource:@"DISK2" ofType:@"ADF"];
-    [path getCString:prefs_df[1] maxLength:256 encoding:[NSString defaultCStringEncoding]];
-    
+        
     // Override point for customization after application launch
     [window makeKeyAndVisible];
     

--- a/TargetSpecific/SingleView/SingleWindowAppDelegate.mm
+++ b/TargetSpecific/SingleView/SingleWindowAppDelegate.mm
@@ -47,7 +47,7 @@
     //Get some view Specific properties
     UINavigationController *navigationcontroller = self.window.rootViewController;
     mainController = navigationcontroller.topViewController;
-        
+    
     // Override point for customization after application launch
     [window makeKeyAndVisible];
     
@@ -99,7 +99,9 @@
 			externalWindow.hidden = YES;
 		}
         
-		[mainController setDisplayViewWindow:nil isExternal:NO];
+        if ([mainController respondsToSelector:@selector(setDisplayViewWindow:isExternal:)]) {
+            [mainController setDisplayViewWindow:nil isExternal:NO];
+        }
 	} else {
 		NSLog(@"External display");
 		UIScreen *secondary = [[UIScreen screens] objectAtIndex:1];

--- a/iUAE.xcodeproj/project.pbxproj
+++ b/iUAE.xcodeproj/project.pbxproj
@@ -174,14 +174,9 @@
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
 		288765FD0DF74451002DB57D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 288765FC0DF74451002DB57D /* CoreGraphics.framework */; };
 		28AD733F0D9D9553002E5188 /* MainWindow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28AD733E0D9D9553002E5188 /* MainWindow.xib */; };
-		7E01A3D91B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 1 of 4).adf in Resources */ = {isa = PBXBuildFile; fileRef = 7E01A3D51B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 1 of 4).adf */; };
-		7E01A3DA1B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 2 of 4).adf in Resources */ = {isa = PBXBuildFile; fileRef = 7E01A3D61B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 2 of 4).adf */; };
-		7E01A3DB1B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 3 of 4).adf in Resources */ = {isa = PBXBuildFile; fileRef = 7E01A3D71B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 3 of 4).adf */; };
-		7E01A3DC1B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 4 of 4).adf in Resources */ = {isa = PBXBuildFile; fileRef = 7E01A3D81B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 4 of 4).adf */; };
 		7E079CC11A81594B00EC0DE4 /* AddConfigurationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E079CC01A81594B00EC0DE4 /* AddConfigurationViewController.m */; };
 		7E0E9594198ACF4C0082F80F /* iOSKeyboard.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E0E9593198ACF4C0082F80F /* iOSKeyboard.png */; };
 		7E10738B1A34E85E000D7269 /* Storyboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7E10738A1A34E85E000D7269 /* Storyboard.storyboard */; };
-		7E1A15921B17228100F0EA17 /* wb13.adf in Resources */ = {isa = PBXBuildFile; fileRef = 7E1A15911B17228100F0EA17 /* wb13.adf */; };
 		7E1B8C3D19FADFD400B6136B /* modejoy.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E1B8C3319FADFD400B6136B /* modejoy.png */; };
 		7E1B8C3F19FADFD400B6136B /* modejoypressed.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E1B8C3519FADFD400B6136B /* modejoypressed.png */; };
 		7E1B8C4119FADFD400B6136B /* modekeyoff.png in Resources */ = {isa = PBXBuildFile; fileRef = 7E1B8C3719FADFD400B6136B /* modekeyoff.png */; };
@@ -235,8 +230,6 @@
 		7EB017731B09143000C74B9D /* SVIndefiniteAnimatedView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EB0176F1B09143000C74B9D /* SVIndefiniteAnimatedView.m */; };
 		7EB017781B09164900C74B9D /* StateFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EB017741B09164900C74B9D /* StateFileManager.m */; };
 		7EB017791B09164900C74B9D /* State.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EB017761B09164900C74B9D /* State.m */; };
-		7EB0177B1B09170D00C74B9D /* kick13.rom in Resources */ = {isa = PBXBuildFile; fileRef = 7EB0177A1B09170D00C74B9D /* kick13.rom */; };
-		7EB0177D1B09174400C74B9D /* Northsou.adf in Resources */ = {isa = PBXBuildFile; fileRef = 7EB0177C1B09174400C74B9D /* Northsou.adf */; };
 		7EB017801B0921B000C74B9D /* SettingsSelectKeyViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EB0177F1B0921B000C74B9D /* SettingsSelectKeyViewController.m */; };
 		7EB372EA1A0FC8DE001B460A /* GameController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7EB372E91A0FC8DE001B460A /* GameController.framework */; };
 		7ED40F1E1A3E1C9300E0E1F8 /* gamepad.png in Resources */ = {isa = PBXBuildFile; fileRef = 7ED40F1D1A3E1C9300E0E1F8 /* gamepad.png */; };
@@ -1542,16 +1535,11 @@
 		28AD733E0D9D9553002E5188 /* MainWindow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = MainWindow.xib; path = iUAEParents/MainWindow.xib; sourceTree = "<group>"; };
 		29B97316FDCFA39411CA2CEA /* main.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = main.mm; path = iUAEParents/main.mm; sourceTree = "<group>"; };
 		32CA4F630368D1EE00C91783 /* iUAE_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iUAE_Prefix.pch; sourceTree = "<group>"; };
-		7E01A3D51B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 1 of 4).adf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Flashback (1992)(U. S. Gold)[cr Interpol](Disk 1 of 4).adf"; path = "../../../Desktop/Flashback (1992)(U. S. Gold)[cr Interpol](Disk 1 of 4).adf"; sourceTree = "<group>"; };
-		7E01A3D61B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 2 of 4).adf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Flashback (1992)(U. S. Gold)[cr Interpol](Disk 2 of 4).adf"; path = "../../../Desktop/Flashback (1992)(U. S. Gold)[cr Interpol](Disk 2 of 4).adf"; sourceTree = "<group>"; };
-		7E01A3D71B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 3 of 4).adf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Flashback (1992)(U. S. Gold)[cr Interpol](Disk 3 of 4).adf"; path = "../../../Desktop/Flashback (1992)(U. S. Gold)[cr Interpol](Disk 3 of 4).adf"; sourceTree = "<group>"; };
-		7E01A3D81B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 4 of 4).adf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Flashback (1992)(U. S. Gold)[cr Interpol](Disk 4 of 4).adf"; path = "../../../Desktop/Flashback (1992)(U. S. Gold)[cr Interpol](Disk 4 of 4).adf"; sourceTree = "<group>"; };
 		7E079CBF1A81594B00EC0DE4 /* AddConfigurationViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AddConfigurationViewController.h; path = Classes/AddConfigurationViewController.h; sourceTree = SOURCE_ROOT; };
 		7E079CC01A81594B00EC0DE4 /* AddConfigurationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AddConfigurationViewController.m; path = Classes/AddConfigurationViewController.m; sourceTree = SOURCE_ROOT; };
 		7E0E9593198ACF4C0082F80F /* iOSKeyboard.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = iOSKeyboard.png; sourceTree = "<group>"; };
 		7E10738A1A34E85E000D7269 /* Storyboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Storyboard.storyboard; path = ../../Storyboard.storyboard; sourceTree = "<group>"; };
 		7E1A15901B171D7E00F0EA17 /* JoypadKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JoypadKey.h; sourceTree = "<group>"; };
-		7E1A15911B17228100F0EA17 /* wb13.adf */ = {isa = PBXFileReference; lastKnownFileType = file; name = wb13.adf; path = ../../../Desktop/wb13.adf; sourceTree = "<group>"; };
 		7E1B8C3319FADFD400B6136B /* modejoy.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = modejoy.png; sourceTree = "<group>"; };
 		7E1B8C3519FADFD400B6136B /* modejoypressed.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = modejoypressed.png; sourceTree = "<group>"; };
 		7E1B8C3719FADFD400B6136B /* modekeyoff.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = modekeyoff.png; sourceTree = "<group>"; };
@@ -1620,8 +1608,6 @@
 		7EB017751B09164900C74B9D /* StateFileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StateFileManager.h; sourceTree = "<group>"; };
 		7EB017761B09164900C74B9D /* State.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = State.m; sourceTree = "<group>"; };
 		7EB017771B09164900C74B9D /* State.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = State.h; sourceTree = "<group>"; };
-		7EB0177A1B09170D00C74B9D /* kick13.rom */ = {isa = PBXFileReference; lastKnownFileType = file; name = kick13.rom; path = ../../../Desktop/kick13.rom; sourceTree = "<group>"; };
-		7EB0177C1B09174400C74B9D /* Northsou.adf */ = {isa = PBXFileReference; lastKnownFileType = file; name = Northsou.adf; path = ../../../Desktop/Northsou.adf; sourceTree = "<group>"; };
 		7EB0177E1B0921B000C74B9D /* SettingsSelectKeyViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SettingsSelectKeyViewController.h; sourceTree = "<group>"; };
 		7EB0177F1B0921B000C74B9D /* SettingsSelectKeyViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SettingsSelectKeyViewController.m; sourceTree = "<group>"; };
 		7EB372E91A0FC8DE001B460A /* GameController.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GameController.framework; path = System/Library/Frameworks/GameController.framework; sourceTree = SDKROOT; };
@@ -2595,11 +2581,6 @@
 		057440D40FC2A4A7003BE251 /* roms */ = {
 			isa = PBXGroup;
 			children = (
-				7E01A3D51B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 1 of 4).adf */,
-				7E01A3D61B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 2 of 4).adf */,
-				7E01A3D71B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 3 of 4).adf */,
-				7E01A3D81B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 4 of 4).adf */,
-				7EB0177A1B09170D00C74B9D /* kick13.rom */,
 			);
 			path = roms;
 			sourceTree = "<group>";
@@ -2607,8 +2588,6 @@
 		057443530FC3CA04003BE251 /* disks */ = {
 			isa = PBXGroup;
 			children = (
-				7E1A15911B17228100F0EA17 /* wb13.adf */,
-				7EB0177C1B09174400C74B9D /* Northsou.adf */,
 			);
 			path = disks;
 			sourceTree = "<group>";
@@ -4067,11 +4046,9 @@
 				28AD733F0D9D9553002E5188 /* MainWindow.xib in Resources */,
 				7E1B8C4519FADFD400B6136B /* options.png in Resources */,
 				05BC1AF81073448200EABC6E /* EMUROMBrowserView.xib in Resources */,
-				7E1A15921B17228100F0EA17 /* wb13.adf in Resources */,
 				7E4B18DF188B1CD70019E82B /* btn_restart.png in Resources */,
 				05BC1B17107348E500EABC6E /* keys.png in Resources */,
 				05BC1B18107348E500EABC6E /* VKBD.PNG in Resources */,
-				7E01A3D91B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 1 of 4).adf in Resources */,
 				7E4B18D5188B1C720019E82B /* chrome-bottom.png in Resources */,
 				7E1B8C4119FADFD400B6136B /* modekeyoff.png in Resources */,
 				7EAA9DC0192541D400541BE1 /* PKCustomKeyboard.xib in Resources */,
@@ -4089,7 +4066,6 @@
 				7EA4D6611923ED0800C58BB9 /* EmulationView-iPad.xib in Resources */,
 				05D5233812E8030E007912AE /* SelectEffectController.xib in Resources */,
 				05619EDC13ADE1AA00341DB0 /* SelectHardware.xib in Resources */,
-				7E01A3DA1B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 2 of 4).adf in Resources */,
 				7ED40F1E1A3E1C9300E0E1F8 /* gamepad.png in Resources */,
 				7E4B18E1188B1CD70019E82B /* btn_restart~ipad.png in Resources */,
 				058063D013B06DD800E00B04 /* Icon-72.png in Resources */,
@@ -4123,15 +4099,11 @@
 				97BE2AF315489E6600BF66CF /* joystick.png in Resources */,
 				97BE2AF915489E6600BF66CF /* mouse.png in Resources */,
 				97BE2AFC15489E6600BF66CF /* ls-fullscreen_bottomBtn.png in Resources */,
-				7E01A3DC1B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 4 of 4).adf in Resources */,
-				7E01A3DB1B31BECB00CD24CC /* Flashback (1992)(U. S. Gold)[cr Interpol](Disk 3 of 4).adf in Resources */,
 				97BE2AFF15489E6600BF66CF /* ls-instructions_overlay.png in Resources */,
 				97BE2B0215489E6600BF66CF /* ls-overlay-skin.png in Resources */,
 				97BE2B0515489E6600BF66CF /* ls-bgimage.png in Resources */,
-				7EB0177B1B09170D00C74B9D /* kick13.rom in Resources */,
 				7EB017721B09143000C74B9D /* SVProgressHUD.bundle in Resources */,
 				97BE2B0815489E6600BF66CF /* ls-fire.png in Resources */,
-				7EB0177D1B09174400C74B9D /* Northsou.adf in Resources */,
 				97BE2B0B15489E6600BF66CF /* ls-joystick_active.png in Resources */,
 				7E4B18D9188B1CAB0019E82B /* chrome-top~ipad.png in Resources */,
 				97BE2B0E15489E6600BF66CF /* ls-joystick_rest.png in Resources */,
@@ -5433,8 +5405,8 @@
 				iOSOpenDevBuildPackageOnAnyBuild = NO;
 				iOSOpenDevCopyOnBuild = NO;
 				iOSOpenDevDevice = 192.168.0.18;
-				iOSOpenDevInstallOnAnyBuild = NO;
-				iOSOpenDevInstallOnProfiling = NO;
+				iOSOpenDevInstallOnAnyBuild = YES;
+				iOSOpenDevInstallOnProfiling = YES;
 				iOSOpenDevRespringOnInstall = YES;
 				iOSOpenDevUsePackageVersionPList = NO;
 			};
@@ -5460,8 +5432,8 @@
 				iOSOpenDevBuildPackageOnAnyBuild = NO;
 				iOSOpenDevCopyOnBuild = NO;
 				iOSOpenDevDevice = 192.168.0.18;
-				iOSOpenDevInstallOnAnyBuild = NO;
-				iOSOpenDevInstallOnProfiling = NO;
+				iOSOpenDevInstallOnAnyBuild = YES;
+				iOSOpenDevInstallOnProfiling = YES;
 				iOSOpenDevRespringOnInstall = YES;
 				iOSOpenDevUsePackageVersionPList = NO;
 			};
@@ -5485,8 +5457,8 @@
 				iOSOpenDevBuildPackageOnAnyBuild = NO;
 				iOSOpenDevCopyOnBuild = NO;
 				iOSOpenDevDevice = 192.168.0.18;
-				iOSOpenDevInstallOnAnyBuild = NO;
-				iOSOpenDevInstallOnProfiling = NO;
+				iOSOpenDevInstallOnAnyBuild = YES;
+				iOSOpenDevInstallOnProfiling = YES;
 				iOSOpenDevRespringOnInstall = YES;
 				iOSOpenDevUsePackageVersionPList = NO;
 			};

--- a/iUAE.xcodeproj/project.pbxproj
+++ b/iUAE.xcodeproj/project.pbxproj
@@ -1262,6 +1262,7 @@
 		97EF968C1538771F001C01E6 /* icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 97EF963E1538771F001C01E6 /* icon.png */; };
 		97EF968D1538771F001C01E6 /* icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 97EF963F1538771F001C01E6 /* icon@2x.png */; };
 		97EF96A31538771F001C01E6 /* StoogesEmulationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 97EF96571538771F001C01E6 /* StoogesEmulationViewController.m */; };
+		BE0921FF1B343D810058D9F2 /* DiskDriveService.mm in Sources */ = {isa = PBXBuildFile; fileRef = BE0921FE1B343D810058D9F2 /* DiskDriveService.mm */; };
 		E18F65E7154CAD470073642F /* Bazooka.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E18F65E6154CAD470073642F /* Bazooka.ttf */; };
 		E18F65EB154CB6960073642F /* intro_5.png in Resources */ = {isa = PBXBuildFile; fileRef = E18F65E8154CB6950073642F /* intro_5.png */; };
 		E18F65EC154CB6960073642F /* intro_5@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E18F65E9154CB6950073642F /* intro_5@2x.png */; };
@@ -2091,6 +2092,8 @@
 		97EF963F1538771F001C01E6 /* icon@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "icon@2x.png"; sourceTree = "<group>"; };
 		97EF96561538771F001C01E6 /* StoogesEmulationViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StoogesEmulationViewController.h; sourceTree = "<group>"; };
 		97EF96571538771F001C01E6 /* StoogesEmulationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StoogesEmulationViewController.m; sourceTree = "<group>"; };
+		BE0921FD1B343D810058D9F2 /* DiskDriveService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DiskDriveService.h; sourceTree = "<group>"; };
+		BE0921FE1B343D810058D9F2 /* DiskDriveService.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DiskDriveService.mm; sourceTree = "<group>"; };
 		E18F65E6154CAD470073642F /* Bazooka.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Bazooka.ttf; sourceTree = "<group>"; };
 		E18F65E8154CB6950073642F /* intro_5.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = intro_5.png; sourceTree = "<group>"; };
 		E18F65E9154CB6950073642F /* intro_5@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "intro_5@2x.png"; sourceTree = "<group>"; };
@@ -2751,6 +2754,8 @@
 				7E2A59B01B052C3300C802E0 /* SettingsJoypadController.m */,
 				7E27C39E1AA3A6D300C00584 /* SettingsDisplayController.m */,
 				7E3C13E41A51F16600534164 /* SettingsGeneralController.m */,
+				BE0921FD1B343D810058D9F2 /* DiskDriveService.h */,
+				BE0921FE1B343D810058D9F2 /* DiskDriveService.mm */,
 			);
 			name = Settings;
 			sourceTree = "<group>";
@@ -4718,6 +4723,7 @@
 				0552BD500F3D797C005B30DF /* savedisk.cpp in Sources */,
 				7EF1681719030597001C8C8F /* TouchHandlerView.m in Sources */,
 				7EB017801B0921B000C74B9D /* SettingsSelectKeyViewController.m in Sources */,
+				BE0921FF1B343D810058D9F2 /* DiskDriveService.mm in Sources */,
 				0552BD510F3D797C005B30DF /* sdlgfx.cpp in Sources */,
 				0552BD540F3D797C005B30DF /* vkbd.cpp in Sources */,
 				0552BD550F3D797C005B30DF /* writelog.cpp in Sources */,

--- a/iUAE.xcodeproj/project.pbxproj
+++ b/iUAE.xcodeproj/project.pbxproj
@@ -5411,8 +5411,8 @@
 				iOSOpenDevBuildPackageOnAnyBuild = NO;
 				iOSOpenDevCopyOnBuild = NO;
 				iOSOpenDevDevice = 192.168.0.18;
-				iOSOpenDevInstallOnAnyBuild = YES;
-				iOSOpenDevInstallOnProfiling = YES;
+				iOSOpenDevInstallOnAnyBuild = NO;
+				iOSOpenDevInstallOnProfiling = NO;
 				iOSOpenDevRespringOnInstall = YES;
 				iOSOpenDevUsePackageVersionPList = NO;
 			};
@@ -5438,8 +5438,8 @@
 				iOSOpenDevBuildPackageOnAnyBuild = NO;
 				iOSOpenDevCopyOnBuild = NO;
 				iOSOpenDevDevice = 192.168.0.18;
-				iOSOpenDevInstallOnAnyBuild = YES;
-				iOSOpenDevInstallOnProfiling = YES;
+				iOSOpenDevInstallOnAnyBuild = NO;
+				iOSOpenDevInstallOnProfiling = NO;
 				iOSOpenDevRespringOnInstall = YES;
 				iOSOpenDevUsePackageVersionPList = NO;
 			};
@@ -5463,8 +5463,8 @@
 				iOSOpenDevBuildPackageOnAnyBuild = NO;
 				iOSOpenDevCopyOnBuild = NO;
 				iOSOpenDevDevice = 192.168.0.18;
-				iOSOpenDevInstallOnAnyBuild = YES;
-				iOSOpenDevInstallOnProfiling = YES;
+				iOSOpenDevInstallOnAnyBuild = NO;
+				iOSOpenDevInstallOnProfiling = NO;
 				iOSOpenDevRespringOnInstall = YES;
 				iOSOpenDevUsePackageVersionPList = NO;
 			};

--- a/iUAEParents/MainEmulationViewController.mm
+++ b/iUAEParents/MainEmulationViewController.mm
@@ -96,8 +96,8 @@ extern void uae_reset();
     [self initMenuBarHidingTimer];
 
     if ([settings boolForKey:@"autoloadconfig"]) {
-        // the emulator isn't initialized correctly right here - we need to delay programmatically inserting floppies by a little
-        [NSTimer scheduledTimerWithTimeInterval:1 target:settings selector:@selector(insertConfiguredFloppies) userInfo:nil repeats:NO];
+        // the emulator isn't initialized yet right here - we need to delay programmatically inserting floppies by a little
+        [NSTimer scheduledTimerWithTimeInterval:.5 target:settings selector:@selector(insertConfiguredFloppies) userInfo:nil repeats:NO];
     }
 }
 

--- a/iUAEParents/MainEmulationViewController.mm
+++ b/iUAEParents/MainEmulationViewController.mm
@@ -95,7 +95,7 @@ extern void uae_reset();
     
     [self initMenuBarHidingTimer];
 
-    if ([settings boolForKey:@"autoloadconfig"]) {
+    if (settings.autoloadConfig) {
         // the emulator isn't initialized yet right here - we need to delay programmatically inserting floppies by a little
         [NSTimer scheduledTimerWithTimeInterval:.5 target:settings selector:@selector(insertConfiguredFloppies) userInfo:nil repeats:NO];
     }

--- a/iUAEParents/MainEmulationViewController.mm
+++ b/iUAEParents/MainEmulationViewController.mm
@@ -211,6 +211,7 @@ extern void uae_reset();
 
 - (void)insertConfiguredDisks {
     [_diskDriveService insertDisks:_settings.insertedFloppies];
+    [_settings setFloppyConfigurations:_settings.insertedFloppies];
 }
 
 - (void)dealloc

--- a/iUAEParents/MainEmulationViewController.mm
+++ b/iUAEParents/MainEmulationViewController.mm
@@ -36,6 +36,7 @@
 #import "UIKitDisplayView.h"
 #import "savestate.h"
 #import "Settings.h"
+#import "DiskDriveService.h"
 
 @interface MainEmulationViewController()
 
@@ -43,7 +44,9 @@
 @end
 
 @implementation MainEmulationViewController {
+    DiskDriveService *_diskDriveService;
     NSTimer *_menuHidingTimer;
+    Settings *_settings;
 }
 
 
@@ -75,6 +78,10 @@ extern void uae_reset();
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+
+    _diskDriveService = [[DiskDriveService alloc] init];
+    _settings = [[Settings alloc] init];
+    
     [self.view setMultipleTouchEnabled:TRUE];
     
     [_btnJoypad setImage: [_btnJoypad.imageView.image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate]
@@ -86,8 +93,7 @@ extern void uae_reset();
                 forState:UIControlStateNormal];
     [_btnPin setTintColor: [UIColor blackColor]];*/
     
-    Settings *settings = [[[Settings alloc] init] autorelease];
-    BOOL isFirstInitialization = [settings initializeSettings];
+    BOOL isFirstInitialization = [_settings initializeSettings];
     if (isFirstInitialization)
     {
         [self showMFIControllerAlert];
@@ -95,9 +101,9 @@ extern void uae_reset();
     
     [self initMenuBarHidingTimer];
 
-    if (settings.autoloadConfig) {
+    if (_settings.autoloadConfig && [_settings.insertedFloppies count] > 0) {
         // the emulator isn't initialized yet right here - we need to delay programmatically inserting floppies by a little
-        [NSTimer scheduledTimerWithTimeInterval:.5 target:settings selector:@selector(insertConfiguredFloppies) userInfo:nil repeats:NO];
+        [NSTimer scheduledTimerWithTimeInterval:.5 target:self selector:@selector(insertConfiguredDisks) userInfo:nil repeats:NO];
     }
 }
 
@@ -203,16 +209,22 @@ extern void uae_reset();
     _menuHidingTimer.tolerance = 0.0020;
 }
 
+- (void)insertConfiguredDisks {
+    [_diskDriveService insertDisks:_settings.insertedFloppies];
+}
+
 - (void)dealloc
 {
-    [_btnKeyboard release];
-    [_menuBar release];
     [_btnJoypad release];
+    [_btnKeyboard release];
     [_btnPin release];
+    [_diskDriveService release];
     [_mouseHandler release];
+    [_menuBar release];
     [_menuBarEnabler release];
     [_menuHidingTimer invalidate];
     [_menuHidingTimer release];
+    [_settings release];
     [super dealloc];
 }
 

--- a/iUAEParents/Settings.h
+++ b/iUAEParents/Settings.h
@@ -10,8 +10,8 @@
 
 @interface Settings : NSObject
 - (void)initializeSettings;
--(void)initializeCommonSettings;
--(void) initializespecificsettings;
+- (void)initializeCommonSettings;
+- (void) initializespecificsettings;
 - (void) setBool:(BOOL)value forKey:(NSString *)settingitemname;
 - (void) setObject:(id)value forKey:(NSString *)settingitemname;
 - (bool) boolForKey:(NSString *)settingitemname;
@@ -20,5 +20,11 @@
 - (void) removeObjectForKey:(NSString *) settingitemname;
 - (NSString *) configForDisk:(NSString *)diskName;
 - (void) setConfig:(NSString *)configName forDisk:(NSString *)diskName;
+
+- (void)setFloppyConfiguration:(NSString *)adfPath;
+
+// floppy related methods - move into their own class
+- (NSString *)getInsertedFloppyForDrive:(int)driveNumber;
+- (void)insertFloppy:(NSString *)adfPath intoDrive:(int)driveNumber;
 
 @end

--- a/iUAEParents/Settings.h
+++ b/iUAEParents/Settings.h
@@ -9,9 +9,13 @@
 #import <Foundation/Foundation.h>
 
 @interface Settings : NSObject
-- (void)initializeSettings;
-- (void)initializeCommonSettings;
-- (void) initializespecificsettings;
+
+/**
+ * Returns YES if this is the very first time the settings are initialized (meaning this must be the first time the app runs).
+ */
+- (BOOL)initializeSettings;
+
+
 - (void) setBool:(BOOL)value forKey:(NSString *)settingitemname;
 - (void) setObject:(id)value forKey:(NSString *)settingitemname;
 - (bool) boolForKey:(NSString *)settingitemname;
@@ -26,5 +30,6 @@
 // floppy related methods - move into their own class
 - (NSString *)getInsertedFloppyForDrive:(int)driveNumber;
 - (void)insertFloppy:(NSString *)adfPath intoDrive:(int)driveNumber;
+- (void)insertConfiguredFloppies;
 
 @end

--- a/iUAEParents/Settings.h
+++ b/iUAEParents/Settings.h
@@ -35,9 +35,4 @@
 - (NSString *)configForDisk:(NSString *)diskName;
 - (void) setConfig:(NSString *)configName forDisk:(NSString *)diskName;
 
-// floppy related methods - move into their own class
-- (NSString *)getInsertedFloppyForDrive:(int)driveNumber;
-- (void)insertFloppy:(NSString *)adfPath intoDrive:(int)driveNumber;
-- (void)insertConfiguredFloppies;
-
 @end

--- a/iUAEParents/Settings.h
+++ b/iUAEParents/Settings.h
@@ -11,21 +11,29 @@
 @interface Settings : NSObject
 
 /**
- * Returns YES if this is the very first time the settings are initialized (meaning this must be the first time the app runs).
+ * Properties for common settings.
+ */
+@property (nonatomic, readwrite, assign) BOOL autoloadConfig;
+@property (nonatomic, readwrite, assign) NSArray *insertedFloppies;
+@property (nonatomic, readwrite, assign) BOOL ntsc;
+@property (nonatomic, readwrite, assign) BOOL stretchScreen;
+@property (nonatomic, readwrite, assign) BOOL showStatus;
+@property (nonatomic, readwrite, assign) NSString *configurationName;
+@property (nonatomic, readwrite, assign) NSArray *configurations;
+
+/**
+ * Returns YES if this is the very first time that the settings are initialized (the firs time the app runs).
  */
 - (BOOL)initializeSettings;
 
-
-- (void) setBool:(BOOL)value forKey:(NSString *)settingitemname;
-- (void) setObject:(id)value forKey:(NSString *)settingitemname;
-- (bool) boolForKey:(NSString *)settingitemname;
-- (NSString *) stringForKey:(NSString *)settingitemname;
-- (NSArray *) arrayForKey:(NSString *)settingitemname;
-- (void) removeObjectForKey:(NSString *) settingitemname;
-- (NSString *) configForDisk:(NSString *)diskName;
+- (void)setBool:(BOOL)value forKey:(NSString *)settingitemname;
+- (void)setObject:(id)value forKey:(NSString *)settingitemname;
+- (bool)boolForKey:(NSString *)settingitemname;
+- (NSString *)stringForKey:(NSString *)settingitemname;
+- (NSArray *)arrayForKey:(NSString *)settingitemname;
+- (void)removeObjectForKey:(NSString *) settingitemname;
+- (NSString *)configForDisk:(NSString *)diskName;
 - (void) setConfig:(NSString *)configName forDisk:(NSString *)diskName;
-
-- (void)setFloppyConfiguration:(NSString *)adfPath;
 
 // floppy related methods - move into their own class
 - (NSString *)getInsertedFloppyForDrive:(int)driveNumber;

--- a/iUAEParents/Settings.h
+++ b/iUAEParents/Settings.h
@@ -26,6 +26,9 @@
  */
 - (BOOL)initializeSettings;
 
+- (void)setFloppyConfigurations:(NSArray *)adfPaths;
+- (void)setFloppyConfiguration:(NSString *)adfPath;
+
 - (void)setBool:(BOOL)value forKey:(NSString *)settingitemname;
 - (void)setObject:(id)value forKey:(NSString *)settingitemname;
 - (bool)boolForKey:(NSString *)settingitemname;

--- a/iUAEParents/Settings.mm
+++ b/iUAEParents/Settings.mm
@@ -77,6 +77,13 @@ static NSString *configurationname;
     return isFirstInitialization;
 }
 
+- (void)setFloppyConfigurations:(NSArray *)adfPaths {
+    for (NSString *adfPath : adfPaths)
+    {
+        [self setFloppyConfiguration:adfPath];
+    }
+}
+
 - (void)setFloppyConfiguration:(NSString *)adfPath {
     NSString *settingstring = [NSString stringWithFormat:@"cnf%@", [adfPath lastPathComponent]];
     if ([defaults stringForKey:settingstring])
@@ -255,8 +262,7 @@ static NSString *configurationname;
     }
 }
 
-- (void)dealloc
-{
+- (void)dealloc {
     [defaults release];
     defaults = nil;
     [super dealloc];

--- a/iUAEParents/Settings.mm
+++ b/iUAEParents/Settings.mm
@@ -14,9 +14,9 @@
 //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //  General Public License for more details.
 //
-// You should have received a copy of the GNU General Public License
-//along with this program; if not, write to the Free Software
-//Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 #import "uae.h"
 #import "sysconfig.h"
@@ -27,6 +27,16 @@
 #import "savestate.h"
 
 #import "Settings.h"
+
+static NSString *const kAppSettingsInitializedKey = @"appvariableinitialized";
+static NSString *const kInitializeKey = @"_initialize";
+static NSString *const kConfigurationNameKey = @"configurationname";
+static NSString *const kConfigurationsKey = @"configurations";
+static NSString *const kAutoloadConfigKey = @"autoloadconfig";
+static NSString *const kNtscKey = @"_ntsc";
+static NSString *const kStretchScreenKey = @"_stretchscreen";
+static NSString *const kShowStatusKey = @"_showstatus";
+static NSString *const kInsertedFloppiesKey = @"insertedfloppies";
 
 extern int mainMenu_showStatus;
 extern int mainMenu_ntsc;
@@ -54,15 +64,15 @@ static NSString *configurationname;
 
 - (BOOL)initializeCommonSettings {
     
-    configurationname = [[defaults stringForKey:@"configurationname"] retain];
+    configurationname = [[defaults stringForKey:kConfigurationNameKey] retain];
     
-    BOOL isFirstInitialization = ![defaults boolForKey:@"appvariableinitialized"];
+    BOOL isFirstInitialization = ![defaults boolForKey:kAppSettingsInitializedKey];
     
     if(isFirstInitialization)
     {
-        [defaults setBool:TRUE forKey:@"appvariableinitialized"];
-        [defaults setBool:FALSE forKey:@"autoloadconfig"];
-        [defaults setObject:@"General" forKey:@"configurationname"];
+        [defaults setBool:TRUE forKey:kAppSettingsInitializedKey];
+        self.autoloadConfig = FALSE;
+        [defaults setObject:@"General" forKey:kConfigurationNameKey];
     }
     return isFirstInitialization;
 }
@@ -74,7 +84,7 @@ static NSString *configurationname;
 }
 
 - (void)insertConfiguredFloppies {
-    NSArray *adfPaths = [self arrayForKey:@"insertedfloppies"];
+    NSArray *adfPaths = self.insertedFloppies;
     for (int driveNumber = 0; driveNumber < [adfPaths count]; driveNumber++)
     {
         if (driveNumber < NUM_DRIVES)
@@ -84,8 +94,8 @@ static NSString *configurationname;
                 continue; // placeholder item
             }
             if ([[NSFileManager defaultManager] fileExistsAtPath:adfPath isDirectory:NULL]) {
-                // it is possible that the stored adf path is no longer valid - this especially happens
-                // during debugging.  If that's the case, don't insert the floppy to avoid confusion
+                // it is possible that the stored adf path is no longer valid - this often happens
+                // during debugging.  If that's the case, don't even attempt to insert the floppy
                 [self insertFloppy:adfPath intoDrive:driveNumber];
             } else {
                 NSLog(@"Adf does not exist: %@", adfPath);
@@ -111,53 +121,110 @@ static NSString *configurationname;
     {
         [configurationname release];
         configurationname = [[defaults stringForKey:settingstring] retain];
-        [defaults setObject:configurationname forKey:@"configurationname"];
+        [defaults setObject:configurationname forKey:kConfigurationNameKey];
     }
 }
 
 - (void)initializespecificsettings {
-    if(![self boolForKey:@"_initialize"])
+    if(![self boolForKey:kInitializeKey])
     {
-        [self setBool:mainMenu_ntsc forKey:@"_ntsc"];
-        [self setBool:mainMenu_stretchscreen forKey:@"_stretchscreen"];
-        [self setBool:mainMenu_showStatus forKey:@"_showstatus"];
-        [self setBool:TRUE forKey:@"_initialize"];
+        self.ntsc = mainMenu_ntsc;
+        self.stretchScreen = mainMenu_stretchscreen;
+        self.showStatus = mainMenu_showStatus;
+        [self setBool:TRUE forKey:kInitializeKey];
     }
     else
     {
-        mainMenu_ntsc = [self boolForKey:@"_ntsc"];
-        mainMenu_stretchscreen = [self boolForKey:@"_stretchscreen"];
-        mainMenu_showStatus = [self boolForKey:@"_showstatus"];
+        mainMenu_ntsc = self.ntsc;
+        mainMenu_stretchscreen = self.stretchScreen;
+        mainMenu_showStatus = self.showStatus;
     }
 }
 
-- (void) setBool:(BOOL)value forKey:(NSString *)settingitemname {
+- (BOOL)autoloadConfig {
+    return [self boolForKey:kAutoloadConfigKey];
+}
+
+- (void)setAutoloadConfig:(BOOL)autoloadConfig {
+    [self setBool:autoloadConfig forKey:kAutoloadConfigKey];
+}
+
+- (NSArray *)insertedFloppies {
+    return [self arrayForKey:kInsertedFloppiesKey];
+}
+
+- (void)setInsertedFloppies:(NSArray *)insertedFloppies {
+    [self setObject:insertedFloppies forKey:kInsertedFloppiesKey];
+}
+
+- (BOOL)ntsc {
+    return [self boolForKey:kNtscKey];
+}
+
+- (void)setNtsc:(BOOL)ntsc {
+    [self setBool:ntsc forKey:kNtscKey];
+}
+
+
+- (BOOL)stretchScreen {
+    return [self boolForKey:kStretchScreenKey];
+}
+
+- (void)setStretchScreen:(BOOL)stretchScreen {
+    [self setBool:stretchScreen forKey:kStretchScreenKey];
+}
+
+- (BOOL)showStatus {
+    return [self boolForKey:kShowStatusKey];
+}
+
+- (void)setShowStatus:(BOOL)showStatus {
+    [self setBool:showStatus forKey:kShowStatusKey];
+}
+
+- (NSString *)configurationName {
+    return [self stringForKey:kConfigurationNameKey];
+}
+
+- (void)setConfigurationName:(NSString *)configurationName {
+    [self setObject:configurationName forKey:kConfigurationNameKey];
+}
+
+- (NSArray *)configurations {
+    return [self arrayForKey:kConfigurationsKey];
+}
+
+- (void)setConfigurations:(NSArray *)configurations {
+    [self setObject:configurations forKey:kConfigurationsKey];
+}
+
+- (void)setBool:(BOOL)value forKey:(NSString *)settingitemname {
     if([settingitemname hasPrefix:@"_"])
     //Setting in own Configuration
     {
-        [defaults setBool:value forKey:[NSString stringWithFormat:@"%@%@", configurationname, settingitemname ]];
+        [defaults setBool:value forKey:[NSString stringWithFormat:@"%@%@", configurationname, settingitemname]];
     }
     else
     //General Setting
     {
-       [defaults setBool:value forKey:[NSString stringWithFormat:@"%@", settingitemname ]];
+        [defaults setBool:value forKey:settingitemname];
     }
 }
          
-- (void) setObject:(id)value forKey:(NSString *)settingitemname {
+- (void)setObject:(id)value forKey:(NSString *)settingitemname {
     if([settingitemname hasPrefix:@"_"])
         //Setting in own Configuration
     {
-        [defaults setObject:value forKey:[NSString stringWithFormat:@"%@%@", configurationname, settingitemname ]];
+        [defaults setObject:value forKey:[NSString stringWithFormat:@"%@%@", configurationname, settingitemname]];
     }
     else
         //General Setting
     {
-        [defaults setObject:value forKey:[NSString stringWithFormat:@"%@", settingitemname ]];
+        [defaults setObject:value forKey:settingitemname];
     }
 }
 
-- (bool) boolForKey:(NSString *)settingitemname {
+- (bool)boolForKey:(NSString *)settingitemname {
     if([settingitemname hasPrefix:@"_"])
     //Setting in own Configuration
     {
@@ -165,11 +232,11 @@ static NSString *configurationname;
     }
     else
     {
-        return [defaults boolForKey:[NSString stringWithFormat:@"%@", settingitemname]];
+        return [defaults boolForKey:settingitemname];
     }
 }
          
-- (NSString *) stringForKey:(NSString *)settingitemname {
+- (NSString *)stringForKey:(NSString *)settingitemname {
     if([settingitemname hasPrefix:@"_"])
         //Setting in own Configuration
     {
@@ -177,11 +244,11 @@ static NSString *configurationname;
     }
     else
     {
-        return [defaults stringForKey:[NSString stringWithFormat:@"%@", settingitemname]];
+        return [defaults stringForKey:settingitemname];
     }
 }
 
-- (NSArray *) arrayForKey:(NSString *)settingitemname {
+- (NSArray *)arrayForKey:(NSString *)settingitemname {
     if([settingitemname hasPrefix:@"_"])
         //Setting in own Configuration
     {
@@ -189,11 +256,11 @@ static NSString *configurationname;
     }
     else
     {
-        return [defaults arrayForKey:[NSString stringWithFormat:@"%@", settingitemname]];
+        return [defaults arrayForKey:settingitemname];
     }
 }
 
-- (void) removeObjectForKey:(NSString *) settingitemname {
+- (void)removeObjectForKey:(NSString *) settingitemname {
     if([settingitemname hasPrefix:@"_"])
         //Setting in own Configuration
     {
@@ -201,17 +268,17 @@ static NSString *configurationname;
     }
     else
     {
-        [defaults removeObjectForKey:[NSString stringWithFormat:@"%@", settingitemname]];
+        [defaults removeObjectForKey:settingitemname];
     }
 }
 
-- (NSString *) configForDisk:(NSString *)diskName {
+- (NSString *)configForDisk:(NSString *)diskName {
 
     NSString *settingstring = [NSString stringWithFormat:@"cnf%@", diskName];
     return [defaults stringForKey:settingstring];
 }
 
-- (void) setConfig:(NSString *)configName forDisk:(NSString *)diskName {
+- (void)setConfig:(NSString *)configName forDisk:(NSString *)diskName {
     
     NSString *configstring = [NSString stringWithFormat:@"cnf%@", diskName];
     

--- a/iUAEParents/Settings.mm
+++ b/iUAEParents/Settings.mm
@@ -55,10 +55,9 @@ static NSString *configurationname;
 
 -(void)initializeCommonSettings {
     
-    NSArray *insertedfloppies = [[defaults arrayForKey:@"insertedfloppies"] mutableCopy];
+    configurationname = [[defaults stringForKey:@"configurationname"] retain];
     
     BOOL appvariableinitializied = [defaults boolForKey:@"appvariableinitialized"];
-    
     if(!appvariableinitializied)
     {
         [defaults setBool:TRUE forKey:@"appvariableinitialized"];
@@ -66,32 +65,34 @@ static NSString *configurationname;
         [defaults setObject:@"General" forKey:@"configurationname"];
     }
     
-    configurationname = [[defaults stringForKey:@"configurationname"] retain];
-    
+    [self insertConfiguredFloppies];
+}
+
+- (void)insertConfiguredFloppies {
+    NSArray *insertedfloppies = [defaults arrayForKey:@"insertedfloppies"];
     for(int i=0;i<NUM_DRIVES;i++)
     {
         NSString *curadf = [insertedfloppies objectAtIndex:i];
         NSString *oldadf = [NSString stringWithCString:changed_df[i] encoding:[NSString defaultCStringEncoding]];
         
-        if(![curadf isEqualToString:oldadf])
+        if(![curadf isEqualToString:oldadf]) // the emulator does this check anyway, we should just insert the floppy the user picked
         {
             [curadf getCString:changed_df[i] maxLength:256 encoding:[NSString defaultCStringEncoding]];
             real_changed_df[i] = 1;
             
             NSString *settingstring = [NSString stringWithFormat:@"cnf%@", [curadf lastPathComponent]];
             
-            if([defaults stringForKey:settingstring] )
+            if([defaults stringForKey:settingstring])
             {
                 [configurationname release];
                 configurationname = [[defaults stringForKey:settingstring] retain];
+                [defaults setObject:configurationname forKey:@"configurationname"];
             }
-            
-            [defaults setObject:configurationname forKey:@"configurationname"];
         }
     }
 }
 
--(void) initializespecificsettings {
+-(void)initializespecificsettings {
     if(![self boolForKey:@"_initialize"])
     {
         [self setBool:mainMenu_ntsc forKey:@"_ntsc"];

--- a/iUAEParents/Settings.mm
+++ b/iUAEParents/Settings.mm
@@ -46,9 +46,10 @@ static NSString *configurationname;
     
 }
 
--(id) init {
-    [super init];
-    defaults = [[NSUserDefaults standardUserDefaults] retain];
+-(id)init {
+    if (self = [super init]) {
+        defaults = [[NSUserDefaults standardUserDefaults] retain];
+    }
     return self;
 }
 

--- a/iUAEParents/Settings.mm
+++ b/iUAEParents/Settings.mm
@@ -77,44 +77,6 @@ static NSString *configurationname;
     return isFirstInitialization;
 }
 
-- (NSString *)getInsertedFloppyForDrive:(int)driveNumber {
-    NSAssert(driveNumber >= 0 && driveNumber <= NUM_DRIVES, @"Bad drive number");
-    NSString *adfPath = [NSString stringWithCString:changed_df[driveNumber] encoding:[NSString defaultCStringEncoding]];
-    return [adfPath length] == 0 ? nil : adfPath;
-}
-
-- (void)insertConfiguredFloppies {
-    NSArray *adfPaths = self.insertedFloppies;
-    for (int driveNumber = 0; driveNumber < [adfPaths count]; driveNumber++)
-    {
-        if (driveNumber < NUM_DRIVES)
-        {
-            NSString *adfPath = [adfPaths objectAtIndex:driveNumber];
-            if ([adfPath length] == 0) {
-                continue; // placeholder item
-            }
-            if ([[NSFileManager defaultManager] fileExistsAtPath:adfPath isDirectory:NULL]) {
-                // it is possible that the stored adf path is no longer valid - this often happens
-                // during debugging.  If that's the case, don't even attempt to insert the floppy
-                [self insertFloppy:adfPath intoDrive:driveNumber];
-            } else {
-                NSLog(@"Adf does not exist: %@", adfPath);
-            }
-        }
-        else
-        {
-            break;
-        }
-    }
-}
-
-- (void)insertFloppy:(NSString *)adfPath intoDrive:(int)driveNumber {
-    NSAssert(driveNumber >= 0 && driveNumber <= NUM_DRIVES, @"Bad drive number");
-    [adfPath getCString:changed_df[driveNumber] maxLength:256 encoding:[NSString defaultCStringEncoding]];
-    real_changed_df[driveNumber] = 1;
-    [self setFloppyConfiguration:adfPath];
-}
-
 - (void)setFloppyConfiguration:(NSString *)adfPath {
     NSString *settingstring = [NSString stringWithFormat:@"cnf%@", [adfPath lastPathComponent]];
     if ([defaults stringForKey:settingstring])

--- a/uae4all_gp2x_0.7.2a/src/disk.cpp
+++ b/uae4all_gp2x_0.7.2a/src/disk.cpp
@@ -1588,8 +1588,8 @@ uae_u8 *restore_disk(int num,uae_u8 *src)
     	drv->dskready = dskready;
     	drv->drive_id_scnt = drive_id_scnt;
     	drv->mfmpos = mfmpos;
-    	strncpy(changed_df[num],(char *)src,127);
-    	changed_df[num][127] = 0;
+    	strncpy(changed_df[num],(char *)src,255);
+    	changed_df[num][255] = 0;
         {
             FILE *f=fopen(changed_df[num],"rb");
             if (f)
@@ -1597,7 +1597,6 @@ uae_u8 *restore_disk(int num,uae_u8 *src)
                 fclose(f);
                 if (strcmp(prefs_df[num],changed_df[num]))
                 {
-                    strcpy(prefs_df[num],changed_df[num]);
                     real_changed_df[num] = 1;
                 }
             }


### PR DESCRIPTION
Hi @emufreak,

I am happy to send you the final pull request related to saving and restoring states.

This pull request has the following changes:

1) Restoring a state now correctly also restores the disks inserted into the disk drives.  I have tested this by playing through Maniac Mansion and using the save/restore state functionality instead of F5 to save the game's progress.  The only issue I have seen is that if you start iUAE and restore a state right away while the rom is loading, the guru starts meditating.  
2) The Settings' df0: and df1: labels are now populated directly from the content of the emulated disk drives, instead of looking at the "insertedfloppies" settings.  This was a necessary refactor for 1) above because the information about the inserted floppies is stored by the emulator in the state file and we have no easy access to it.
3) Fix for the "autoload config" toggle - when enabled, the persisted floppies from the "insertedfloppies" setting are now correctly inserted when iUAE starts.
4) Fix for crash when quitting iUAE (using the "home" button) while in settings in then starting iUAE again.

Code level changes/refactoring:
1) Common settings are now properties on the Settings class - this is somewhat nicer than hardcoding the property names (such as "insertedfloppies") in multiple places.
2) Interactions with floppy drives now live in "DiskDriveService".
3) I removed references to rom/adfs from the project file - let's not commit these references to GitHub so that anybody can easily build iUAE... 

I have done a fair amount of testing so I am fairly confident I did not break anything.  Please let me know right away if you see some strange behaviour and I will fix asap.

Regards - Simon 
