### PR TITLE
Add switches to disable drives.

### DIFF
--- a/Classes/DiskDriveService.h
+++ b/Classes/DiskDriveService.h
@@ -15,6 +15,7 @@
 //  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 #import <Foundation/Foundation.h>
+#import "DriveState.h"
 
 /**
  * The disk drive service handles interactions with the disk drives.
@@ -55,5 +56,15 @@
  * Enables/disables the specified drive.
  */
 - (void)enableDrive:(NSUInteger)driveNumber enable:(BOOL)enable;
+
+/**
+ * Returns a DriveState instance that has enabled/disabled information for all drives.
+ */
+- (DriveState *)getDriveState;
+
+/**
+ * Enables/disables drives as specified in the given driveState instance.
+ */
+- (void)setDriveState:(DriveState *)driveState;
 
 @end

--- a/Classes/DiskDriveService.h
+++ b/Classes/DiskDriveService.h
@@ -54,6 +54,6 @@
 /**
  * Enables/disables the specified drive.
  */
-- (void)enableDrive:(NSUInteger)driveNumber enabled:(BOOL)enabled;
+- (void)enableDrive:(NSUInteger)driveNumber enable:(BOOL)enable;
 
 @end

--- a/Classes/DiskDriveService.h
+++ b/Classes/DiskDriveService.h
@@ -39,11 +39,21 @@
 /**
  * Ejects the disk from the specified drive number.
  */
-- (void)ejectDiskFromDrive:(int)driveNumber;
+- (void)ejectDiskFromDrive:(NSUInteger)driveNumber;
 
 /**
- * Returns YES if a disk is inserted into the specified drive.
+ * Returns YES if a disk is currently inserted into the specified drive, NO otherwise.
  */
-- (BOOL)diskInsertedIntoDrive:(int)driveNumber;
+- (BOOL)diskInsertedIntoDrive:(NSUInteger)driveNumber;
+
+/**
+ * Returns YES if the specified is enabled, NO otherwise.
+ */
+- (BOOL)enabled:(NSUInteger)driveNumber;
+
+/**
+ * Enables/disables the specified drive.
+ */
+- (void)enableDrive:(NSUInteger)driveNumber enabled:(BOOL)enabled;
 
 @end

--- a/Classes/DiskDriveService.mm
+++ b/Classes/DiskDriveService.mm
@@ -80,14 +80,20 @@
 }
 
 - (BOOL)enabled:(NSUInteger)driveNumber {
-    return (disabled & (1 << driveNumber)) == 0;
+    if (driveNumber < NUM_DRIVES)
+    {
+        return (disabled & (1 << driveNumber)) == 0;
+    }
+    return NO;
 }
 
-- (void)enableDrive:(NSUInteger)driveNumber enabled:(BOOL)enabled {
+- (void)enableDrive:(NSUInteger)driveNumber enable:(BOOL)enable {
     if (driveNumber < NUM_DRIVES) {
-        if (enabled) {
+        if (enable && ![self enabled:driveNumber])
+        {
             disabled -= (1 << driveNumber);
-        } else {
+        } else if (!enable && [self enabled:driveNumber])
+        {
             disabled += (1 << driveNumber);
         }
     }

--- a/Classes/DiskDriveService.mm
+++ b/Classes/DiskDriveService.mm
@@ -49,10 +49,10 @@
                 continue; // placeholder item
             }
             if ([[NSFileManager defaultManager] fileExistsAtPath:adfPath isDirectory:NULL]) {
-                // it is possible that the stored adf path is no longer valid - this often happens
-                // during debugging.  If that's the case, don't even attempt to insert the floppy
                 [self insertDisk:adfPath intoDrive:driveNumber];
             } else {
+                // it is possible that the stored adf path is no longer valid - this often happens
+                // during debugging.  If that's the case, don't even attempt to insert the floppy
                 NSLog(@"adf does not exist: %@", adfPath);
             }
         }

--- a/Classes/DiskDriveService.mm
+++ b/Classes/DiskDriveService.mm
@@ -99,4 +99,24 @@
     }
 }
 
+- (DriveState *)getDriveState {
+    DriveState *driveState = [[[DriveState alloc] init] autorelease];
+    driveState.df1Enabled = [self enabled:1];
+    driveState.df2Enabled = [self enabled:2];
+    driveState.df3Enabled = [self enabled:3];
+    return driveState;
+}
+
+- (void)setDriveState:(DriveState *)driveState {
+    if (NUM_DRIVES > 1) {
+        [self enableDrive:1 enable:driveState.df1Enabled];
+    }
+    if (NUM_DRIVES > 2) {
+        [self enableDrive:2 enable:driveState.df2Enabled];
+    }
+    if (NUM_DRIVES > 3) {
+        [self enableDrive:3 enable:driveState.df3Enabled];
+    }
+}
+
 @end

--- a/Classes/DiskDriveService.mm
+++ b/Classes/DiskDriveService.mm
@@ -63,7 +63,7 @@
     }
 }
 
-- (void)ejectDiskFromDrive:(int)driveNumber {
+- (void)ejectDiskFromDrive:(NSUInteger)driveNumber {
     if (driveNumber < NUM_DRIVES)
     {
         changed_df[driveNumber][0] = 0;
@@ -71,12 +71,26 @@
     }
 }
 
-- (BOOL)diskInsertedIntoDrive:(int)driveNumber {
+- (BOOL)diskInsertedIntoDrive:(NSUInteger)driveNumber {
     if (driveNumber < NUM_DRIVES)
     {
         return changed_df[driveNumber][0] != 0;
     }
     return NO;
+}
+
+- (BOOL)enabled:(NSUInteger)driveNumber {
+    return (disabled & (1 << driveNumber)) == 0;
+}
+
+- (void)enableDrive:(NSUInteger)driveNumber enabled:(BOOL)enabled {
+    if (driveNumber < NUM_DRIVES) {
+        if (enabled) {
+            disabled -= (1 << driveNumber);
+        } else {
+            disabled += (1 << driveNumber);
+        }
+    }
 }
 
 @end

--- a/Classes/DriveState.h
+++ b/Classes/DriveState.h
@@ -1,0 +1,35 @@
+//  Created by Simon Toens on 10.07.15
+//
+//  iUAE is free software: you may copy, redistribute
+//  and/or modify it under the terms of the GNU General Public License as
+//  published by the Free Software Foundation, either version 2 of the
+//  License, or (at your option) any later version.
+//
+//  This file is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+#import <Foundation/Foundation.h>
+
+/**
+ * Tracks enabled/disabled state of drives.
+ *
+ * This is a convenience class to group the state of all drives in one place - updating the properties does not affect the actual drive states!
+ */
+@interface DriveState : NSObject
+
+/**
+ * Returns a DriveState instace with all drives enabled.
+ */
++ (DriveState *)getAllEnabled;
+
+@property (nonatomic, assign) BOOL df1Enabled;
+@property (nonatomic, assign) BOOL df2Enabled;
+@property (nonatomic, assign) BOOL df3Enabled;
+
+@end

--- a/Classes/DriveState.m
+++ b/Classes/DriveState.m
@@ -1,0 +1,29 @@
+//  Created by Simon Toens on 10.07.15
+//
+//  iUAE is free software: you may copy, redistribute
+//  and/or modify it under the terms of the GNU General Public License as
+//  published by the Free Software Foundation, either version 2 of the
+//  License, or (at your option) any later version.
+//
+//  This file is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+#import "DriveState.h"
+
+@implementation DriveState
+
++ (DriveState *)getAllEnabled {
+    DriveState *driveState = [[[DriveState alloc] init] autorelease];
+    driveState.df1Enabled = YES;
+    driveState.df2Enabled = YES;
+    driveState.df3Enabled = YES;
+    return driveState;
+}
+
+@end

--- a/Classes/ResetController.h
+++ b/Classes/ResetController.h
@@ -1,0 +1,33 @@
+//  Created by Simon Toens on 10.07.15
+//
+//  iUAE is free software: you may copy, redistribute
+//  and/or modify it under the terms of the GNU General Public License as
+//  published by the Free Software Foundation, either version 2 of the
+//  License, or (at your option) any later version.
+//
+//  This file is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+
+#import <Foundation/Foundation.h>
+#import "DriveState.h"
+
+@protocol ResetDelegate
+
+- (void)didSelectReset:(DriveState *)driveState;
+
+@end
+
+@interface ResetController : UIViewController
+
+@property (nonatomic, readonly) DriveState *driveState;
+
+@property (nonatomic, assign) id<ResetDelegate> delegate;
+
+@end

--- a/Classes/ResetController.m
+++ b/Classes/ResetController.m
@@ -1,0 +1,61 @@
+//  Created by Simon Toens on 10.07.15
+//
+//  iUAE is free software: you may copy, redistribute
+//  and/or modify it under the terms of the GNU General Public License as
+//  published by the Free Software Foundation, either version 2 of the
+//  License, or (at your option) any later version.
+//
+//  This file is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+#import "ResetController.h"
+#import "DiskDriveService.h"
+
+@interface ResetController()
+@property (readwrite, assign) IBOutlet UISwitch *df1Switch;
+@property (readwrite, assign) IBOutlet UISwitch *df2Switch;
+@property (readwrite, assign) IBOutlet UISwitch *df3Switch;
+@end
+
+@implementation ResetController {
+    DiskDriveService *_diskDriveService;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    _diskDriveService = [[DiskDriveService alloc] init];
+    _driveState = [[_diskDriveService getDriveState] retain];
+    [_df1Switch setOn:_driveState.df1Enabled];
+    [_df2Switch setOn:_driveState.df2Enabled];
+    [_df3Switch setOn:_driveState.df3Enabled];
+}
+
+- (IBAction)onResetConfirmed {
+    [self.delegate didSelectReset:_driveState];
+    [self.navigationController popToRootViewControllerAnimated:YES];
+}
+
+- (IBAction)toggleDF1Switch {
+    _driveState.df1Enabled = _df1Switch.isOn;
+}
+
+- (IBAction)toggleDF2Switch {
+    _driveState.df2Enabled = _df2Switch.isOn;
+}
+
+- (IBAction)toggleDF3Switch {
+    _driveState.df3Enabled = _df3Switch.isOn;
+}
+
+- (void)dealloc {
+    [_diskDriveService release];
+    [super dealloc];
+}
+
+@end

--- a/Classes/SettingsGeneralController.h
+++ b/Classes/SettingsGeneralController.h
@@ -30,6 +30,9 @@
 @property (readwrite, retain) IBOutlet UILabel *df1;
 @property (readwrite, retain) IBOutlet UILabel *df2;
 @property (readwrite, retain) IBOutlet UILabel *df3;
+@property (readwrite, retain) IBOutlet UISwitch *df1Switch;
+@property (readwrite, retain) IBOutlet UISwitch *df2Switch;
+@property (readwrite, retain) IBOutlet UISwitch *df3Switch;
 @property (readwrite, retain) IBOutlet UILabel *configurationname;
 @property (readwrite, retain) IBOutlet UITableViewCell *cellconfiguration;
 

--- a/Classes/SettingsGeneralController.h
+++ b/Classes/SettingsGeneralController.h
@@ -19,6 +19,7 @@
 //Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 #import <UIKit/UIKit.h>
+#import "ResetController.h"
 #import "EMUROMBrowserViewController.h"
 #import "SelectConfigurationViewController.h"
 
@@ -37,7 +38,6 @@
 @property (readwrite, retain) IBOutlet UITableViewCell *cellconfiguration;
 
 @property (readwrite, retain) UIImage *emulatorScreenshot;
+@property (readwrite, assign) id<ResetDelegate> resetDelegate;
 
 @end
-
-

--- a/Classes/SettingsGeneralController.mm
+++ b/Classes/SettingsGeneralController.mm
@@ -53,6 +53,13 @@ static NSString *const kStateManagementSegue = @"StateManagement";
     [self setupFloppyLabels];
     [self setupAutoloadConfigSwitch];
     [self setupConfigurationName];
+    [self setupDriveSwitches];
+}
+
+- (void)setupDriveSwitches {
+    [_df1Switch setOn:[diskDriveService enabled:1]];
+    [_df2Switch setOn:[diskDriveService enabled:2]];
+    [_df3Switch setOn:[diskDriveService enabled:3]];
 }
 
 - (void)setupFloppyLabels {
@@ -82,6 +89,21 @@ static NSString *const kStateManagementSegue = @"StateManagement";
 
 - (IBAction)toggleAutoloadconfig:(id)sender {
     settings.autoloadConfig = !settings.autoloadConfig;
+}
+
+// Whether a disk drive is enabled or disabled is currently not persisted in settings
+// because when the emulator is reset, DISK_reset (in disk.cpp) always
+// enables all drives...that logic would have to change.
+- (IBAction)toggleDF1Switch {
+    [diskDriveService enableDrive:1 enabled:_df1Switch.isOn];
+}
+
+- (IBAction)toggleDF2Switch {
+    [diskDriveService enableDrive:2 enabled:_df2Switch.isOn];
+}
+
+- (IBAction)toggleDF3Switch {
+    [diskDriveService enableDrive:3 enabled:_df3Switch.isOn];
 }
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
@@ -202,6 +224,7 @@ static NSString *const kStateManagementSegue = @"StateManagement";
 - (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
     if (buttonIndex == 0) { // OK button
         uae_reset();
+        [self setupUIState];
         [SVProgressHUD setBackgroundColor:[UIColor lightGrayColor]];
         [SVProgressHUD showSuccessWithStatus:@"Reset Amiga"];
     }

--- a/Classes/SettingsGeneralController.mm
+++ b/Classes/SettingsGeneralController.mm
@@ -95,15 +95,15 @@ static NSString *const kStateManagementSegue = @"StateManagement";
 // because when the emulator is reset, DISK_reset (in disk.cpp) always
 // enables all drives...that logic would have to change.
 - (IBAction)toggleDF1Switch {
-    [diskDriveService enableDrive:1 enabled:_df1Switch.isOn];
+    [diskDriveService enableDrive:1 enable:_df1Switch.isOn];
 }
 
 - (IBAction)toggleDF2Switch {
-    [diskDriveService enableDrive:2 enabled:_df2Switch.isOn];
+    [diskDriveService enableDrive:2 enable:_df2Switch.isOn];
 }
 
 - (IBAction)toggleDF3Switch {
-    [diskDriveService enableDrive:3 enabled:_df3Switch.isOn];
+    [diskDriveService enableDrive:3 enable:_df3Switch.isOn];
 }
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/Storyboard.storyboard
+++ b/Storyboard.storyboard
@@ -292,7 +292,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xdG-Cz-1b4" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="253.125" y="2384.1549295774648"/>
+            <point key="canvasLocation" x="-231" y="2368"/>
         </scene>
         <!--General-->
         <scene sceneID="PjW-da-JQv">
@@ -352,11 +352,8 @@
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nr6-vh-K16" userLabel="DF1Switch">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nr6-vh-K16" userLabel="DF1Switch">
                                                     <rect key="frame" x="934" y="6" width="51" height="31"/>
-                                                    <connections>
-                                                        <action selector="toggleDF1Switch" destination="fDF-e7-E6W" eventType="touchUpInside" id="rkC-hE-pbR"/>
-                                                    </connections>
                                                 </switch>
                                             </subviews>
                                             <constraints>
@@ -388,11 +385,8 @@
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="f2Q-d6-qne" userLabel="DF2Switch">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="f2Q-d6-qne" userLabel="DF2Switch">
                                                     <rect key="frame" x="934" y="6" width="51" height="31"/>
-                                                    <connections>
-                                                        <action selector="toggleDF2Switch" destination="fDF-e7-E6W" eventType="touchUpInside" id="jfL-Kd-xxa"/>
-                                                    </connections>
                                                 </switch>
                                             </subviews>
                                             <constraints>
@@ -424,11 +418,8 @@
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kut-sx-3Td" userLabel="DF3Switch">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kut-sx-3Td" userLabel="DF3Switch">
                                                     <rect key="frame" x="934" y="6" width="51" height="31"/>
-                                                    <connections>
-                                                        <action selector="toggleDF3Switch" destination="fDF-e7-E6W" eventType="touchUpInside" id="3jk-UK-xPX"/>
-                                                    </connections>
                                                 </switch>
                                             </subviews>
                                             <constraints>
@@ -539,14 +530,14 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="nyu-dL-Nsw">
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="nyu-dL-Nsw">
                                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="nyu-dL-Nsw" id="eCl-uu-Z0A">
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Reset Amiga" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IZT-FH-jk7">
-                                                    <rect key="frame" x="11" y="11" width="102" height="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Reset Amiga/Configure Drives" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IZT-FH-jk7">
+                                                    <rect key="frame" x="11" y="11" width="235" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -588,6 +579,7 @@
                         <segue destination="35x-lU-B56" kind="show" identifier="AssignDiskfiles" id="FAe-3z-c5O"/>
                         <segue destination="Tgl-MA-LZa" kind="show" identifier="LoadConfiguration" id="yz1-cx-vwd"/>
                         <segue destination="V0G-7J-pcz" kind="show" identifier="StateManagement" id="NTn-Bh-1Qa"/>
+                        <segue destination="kfq-Cz-QXO" kind="show" identifier="ConfirmReset" id="dsS-aL-aVx"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5VK-Vz-1xK" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1216,7 +1208,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iPk-ZN-tzf" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2218.125" y="4455.6338028169012"/>
+            <point key="canvasLocation" x="2267" y="4455"/>
         </scene>
         <!--Add Configuration View Controller-->
         <scene sceneID="fUf-eb-kao">
@@ -1288,6 +1280,110 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="KJR-7a-wPW" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2218.125" y="5530.9859154929563"/>
+        </scene>
+        <!--Reset Controller-->
+        <scene sceneID="M6m-vb-Ii7">
+            <objects>
+                <viewController id="kfq-Cz-QXO" customClass="ResetController" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="qri-xU-WhL"/>
+                        <viewControllerLayoutGuide type="bottom" id="dCs-Fp-Ta8"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="vdh-p3-w5d">
+                        <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Really reset the emulator state?" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X2T-4D-kXF">
+                                <rect key="frame" x="19" y="79" width="254" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zRH-YA-HCn">
+                                <rect key="frame" x="46" y="115" width="28" height="30"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                                <state key="normal" title="OK">
+                                    <color key="titleColor" red="0.002163004113" green="0.28005751490000003" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="onResetConfirmed" destination="kfq-Cz-QXO" eventType="touchUpInside" id="Ekg-a8-2Wx"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Enable/Disable drives at reset:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ssO-KH-g6J">
+                                <rect key="frame" x="17" y="175" width="238" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="DF1:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ELb-lf-B8a">
+                                <rect key="frame" x="46" y="213" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fXq-ak-ldR">
+                                <rect key="frame" x="103" y="207" width="51" height="31"/>
+                                <connections>
+                                    <action selector="toggleDF1Switch" destination="kfq-Cz-QXO" eventType="touchUpInside" id="ofR-kB-ynq"/>
+                                </connections>
+                            </switch>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="DF2:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Woq-hn-0hI">
+                                <rect key="frame" x="46" y="252" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KUC-3r-b6d">
+                                <rect key="frame" x="103" y="246" width="51" height="31"/>
+                                <connections>
+                                    <action selector="toggleDF2Switch" destination="kfq-Cz-QXO" eventType="touchUpInside" id="Xdm-Z3-jB1"/>
+                                </connections>
+                            </switch>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="DF3:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HkH-H9-mlV">
+                                <rect key="frame" x="46" y="287" width="42" height="30"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rQI-Gy-0cf">
+                                <rect key="frame" x="103" y="287" width="51" height="31"/>
+                                <connections>
+                                    <action selector="toggleDF3Switch" destination="kfq-Cz-QXO" eventType="touchUpInside" id="hTP-pR-L8M"/>
+                                </connections>
+                            </switch>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="X2T-4D-kXF" firstAttribute="top" secondItem="qri-xU-WhL" secondAttribute="bottom" constant="15" id="8mM-wY-g1Y"/>
+                            <constraint firstItem="HkH-H9-mlV" firstAttribute="leading" secondItem="vdh-p3-w5d" secondAttribute="leadingMargin" constant="30" id="9Bp-Z7-5Jw"/>
+                            <constraint firstItem="X2T-4D-kXF" firstAttribute="leading" secondItem="vdh-p3-w5d" secondAttribute="leadingMargin" constant="15" id="BNE-vg-1Q4"/>
+                            <constraint firstItem="fXq-ak-ldR" firstAttribute="leading" secondItem="ELb-lf-B8a" secondAttribute="trailing" constant="15" id="BYK-rP-OxB"/>
+                            <constraint firstItem="rQI-Gy-0cf" firstAttribute="top" secondItem="KUC-3r-b6d" secondAttribute="bottom" constant="10" id="Cfj-IX-YPD"/>
+                            <constraint firstItem="KUC-3r-b6d" firstAttribute="leading" secondItem="Woq-hn-0hI" secondAttribute="trailing" constant="15" id="Ed1-SA-na0"/>
+                            <constraint firstItem="fXq-ak-ldR" firstAttribute="top" secondItem="ssO-KH-g6J" secondAttribute="bottom" constant="10" id="FTR-zz-8kK"/>
+                            <constraint firstItem="Woq-hn-0hI" firstAttribute="top" secondItem="ELb-lf-B8a" secondAttribute="bottom" constant="20" id="GwB-Kf-W2a"/>
+                            <constraint firstItem="ELb-lf-B8a" firstAttribute="top" secondItem="ssO-KH-g6J" secondAttribute="bottom" constant="15" id="Ix4-6J-mTX"/>
+                            <constraint firstItem="zRH-YA-HCn" firstAttribute="leading" secondItem="vdh-p3-w5d" secondAttribute="leadingMargin" constant="30" id="L9M-UI-mzB"/>
+                            <constraint firstItem="KUC-3r-b6d" firstAttribute="top" secondItem="fXq-ak-ldR" secondAttribute="bottom" constant="10" id="acr-tg-CNQ"/>
+                            <constraint firstItem="HkH-H9-mlV" firstAttribute="top" secondItem="Woq-hn-0hI" secondAttribute="bottom" constant="20" id="cfA-4M-voT"/>
+                            <constraint firstItem="ssO-KH-g6J" firstAttribute="leading" secondItem="vdh-p3-w5d" secondAttribute="leadingMargin" constant="15" id="drH-2x-FpB"/>
+                            <constraint firstItem="Woq-hn-0hI" firstAttribute="leading" secondItem="vdh-p3-w5d" secondAttribute="leadingMargin" constant="30" id="eX0-YZ-Gqr"/>
+                            <constraint firstItem="rQI-Gy-0cf" firstAttribute="leading" secondItem="HkH-H9-mlV" secondAttribute="trailing" constant="15" id="hsI-gc-EHG"/>
+                            <constraint firstItem="zRH-YA-HCn" firstAttribute="top" secondItem="X2T-4D-kXF" secondAttribute="bottom" constant="15" id="kF1-sV-ZGC"/>
+                            <constraint firstItem="ssO-KH-g6J" firstAttribute="top" secondItem="zRH-YA-HCn" secondAttribute="bottom" constant="30" id="ksc-Jf-8N7"/>
+                            <constraint firstItem="ELb-lf-B8a" firstAttribute="leading" secondItem="vdh-p3-w5d" secondAttribute="leadingMargin" constant="30" id="m5z-Vr-213"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="df1Switch" destination="fXq-ak-ldR" id="noe-1y-ao7"/>
+                        <outlet property="df2Switch" destination="KUC-3r-b6d" id="9tZ-yi-eQh"/>
+                        <outlet property="df3Switch" destination="rQI-Gy-0cf" id="t6v-ae-hSB"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="4kJ-nG-CGb" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="993" y="2379"/>
         </scene>
         <!--Browser View Controller-->
         <scene sceneID="c11-yF-e1b">

--- a/Storyboard.storyboard
+++ b/Storyboard.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="EnC-f2-lWs">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="EnC-f2-lWs">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
@@ -21,21 +21,21 @@
                             <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8JE-eY-9II" userLabel="joycontroller" customClass="InputControllerView">
                                 <rect key="frame" x="0.0" y="0.0" width="1024" height="724"/>
                                 <subviews>
-                                    <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7qW-dZ-P7e" userLabel="Mouse handler" customClass="TouchHandlerViewClassic">
+                                    <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7qW-dZ-P7e" userLabel="Mouse handler" customClass="TouchHandlerViewClassic">
                                         <rect key="frame" x="0.0" y="0.0" width="1024" height="724"/>
                                         <subviews>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="44g-VP-zUI">
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="44g-VP-zUI">
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocorrectionType="no"/>
                                             </textField>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gQf-EM-UOL">
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gQf-EM-UOL">
                                                 <constraints>
                                                     <constraint firstAttribute="height" id="swQ-yM-PIK"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocorrectionType="no"/>
                                             </textField>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="YZd-03-fs2">
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="YZd-03-fs2">
                                                 <constraints>
                                                     <constraint firstAttribute="width" id="Quv-yc-erv"/>
                                                 </constraints>
@@ -315,10 +315,10 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="DF0:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ybp-NV-rRY">
                                                     <rect key="frame" x="12" y="10" width="42" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="620-hp-l7l" userLabel="DF0InsertedDiskLabel">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="right" lineBreakMode="headTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="620-hp-l7l" userLabel="DF0InsertedDiskLabel">
                                                     <rect key="frame" x="489" y="11" width="500" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
@@ -328,7 +328,7 @@
                                             <constraints>
                                                 <constraint firstItem="Ybp-NV-rRY" firstAttribute="leading" secondItem="pwu-2p-Gs1" secondAttribute="leadingMargin" constant="5" id="BIb-cw-BM0"/>
                                                 <constraint firstAttribute="centerY" secondItem="Ybp-NV-rRY" secondAttribute="centerY" constant="1" id="ckK-nK-f0z"/>
-                                                <constraint firstItem="620-hp-l7l" firstAttribute="leading" secondItem="pwu-2p-Gs1" secondAttribute="leadingMargin" constant="38" id="grp-XC-z8o"/>
+                                                <constraint firstItem="620-hp-l7l" firstAttribute="leading" secondItem="pwu-2p-Gs1" secondAttribute="leadingMargin" constant="46" id="grp-XC-z8o"/>
                                                 <constraint firstAttribute="centerY" secondItem="620-hp-l7l" secondAttribute="centerY" id="pjg-FL-Mp7"/>
                                                 <constraint firstAttribute="trailingMargin" secondItem="620-hp-l7l" secondAttribute="trailing" constant="5" id="sWh-Fs-ceg"/>
                                             </constraints>
@@ -342,23 +342,31 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="DF1:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ey2-kT-rDi">
                                                     <rect key="frame" x="13" y="11" width="42" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wyq-9t-jBF" userLabel="DF1InsertedDiskLabel">
-                                                    <rect key="frame" x="481" y="11" width="500" height="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="right" lineBreakMode="headTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wyq-9t-jBF" userLabel="DF1InsertedDiskLabel">
+                                                    <rect key="frame" x="54" y="11" width="869" height="21"/>
                                                     <color key="tintColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nr6-vh-K16" userLabel="DF1Switch">
+                                                    <rect key="frame" x="934" y="6" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="toggleDF1Switch" destination="fDF-e7-E6W" eventType="touchUpInside" id="rkC-hE-pbR"/>
+                                                    </connections>
+                                                </switch>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstAttribute="centerY" secondItem="ey2-kT-rDi" secondAttribute="centerY" id="9fQ-9z-GNU"/>
-                                                <constraint firstItem="Wyq-9t-jBF" firstAttribute="leading" secondItem="gs2-0K-ro6" secondAttribute="leadingMargin" constant="38" id="Hbp-i0-esu"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="Wyq-9t-jBF" secondAttribute="trailing" constant="5" id="Om3-k4-6BW"/>
+                                                <constraint firstItem="Nr6-vh-K16" firstAttribute="trailing" secondItem="gs2-0K-ro6" secondAttribute="trailingMargin" id="Rjz-WD-0wv"/>
                                                 <constraint firstItem="ey2-kT-rDi" firstAttribute="leading" secondItem="gs2-0K-ro6" secondAttribute="leadingMargin" constant="5" id="UFy-ai-Hru"/>
+                                                <constraint firstAttribute="centerY" secondItem="Nr6-vh-K16" secondAttribute="centerY" id="goP-0s-PJF"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="Wyq-9t-jBF" secondAttribute="trailing" constant="60" id="kjr-0H-d1g"/>
                                                 <constraint firstAttribute="centerY" secondItem="Wyq-9t-jBF" secondAttribute="centerY" id="nSp-2t-c6R"/>
+                                                <constraint firstItem="Wyq-9t-jBF" firstAttribute="leading" secondItem="gs2-0K-ro6" secondAttribute="leadingMargin" constant="46" id="yJn-Uu-qkI"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -370,23 +378,31 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="DF2:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bDP-yJ-bKF">
                                                     <rect key="frame" x="13" y="11" width="42" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rhj-tQ-Zya" userLabel="DF12nsertedDiskLabel">
-                                                    <rect key="frame" x="481" y="11" width="500" height="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="right" lineBreakMode="headTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rhj-tQ-Zya" userLabel="DF12nsertedDiskLabel">
+                                                    <rect key="frame" x="54" y="11" width="869" height="21"/>
                                                     <color key="tintColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="f2Q-d6-qne" userLabel="DF2Switch">
+                                                    <rect key="frame" x="934" y="6" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="toggleDF2Switch" destination="fDF-e7-E6W" eventType="touchUpInside" id="jfL-Kd-xxa"/>
+                                                    </connections>
+                                                </switch>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="Rhj-tQ-Zya" firstAttribute="leading" secondItem="j2a-ej-AUQ" secondAttribute="leadingMargin" constant="38" id="065-Gg-8Aw"/>
+                                                <constraint firstItem="Rhj-tQ-Zya" firstAttribute="leading" secondItem="j2a-ej-AUQ" secondAttribute="leadingMargin" constant="46" id="065-Gg-8Aw"/>
                                                 <constraint firstItem="bDP-yJ-bKF" firstAttribute="leading" secondItem="j2a-ej-AUQ" secondAttribute="leadingMargin" constant="5" id="3OT-JX-EjE"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="f2Q-d6-qne" secondAttribute="trailing" id="8uQ-pg-ENj"/>
                                                 <constraint firstAttribute="centerY" secondItem="Rhj-tQ-Zya" secondAttribute="centerY" id="DJU-Ge-9iE"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="Rhj-tQ-Zya" secondAttribute="trailing" constant="5" id="TIw-ty-s0m"/>
+                                                <constraint firstAttribute="centerY" secondItem="f2Q-d6-qne" secondAttribute="centerY" id="Vfh-PK-dJ6"/>
                                                 <constraint firstAttribute="centerY" secondItem="bDP-yJ-bKF" secondAttribute="centerY" id="YaO-6k-Nx8"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="Rhj-tQ-Zya" secondAttribute="trailing" constant="60" id="bil-j0-Bmr"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -398,23 +414,31 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="DF3:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WPl-cA-X9c">
                                                     <rect key="frame" x="13" y="11" width="42" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="soj-mJ-3y3" userLabel="DF13nsertedDiskLabel">
-                                                    <rect key="frame" x="481" y="11" width="500" height="21"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" textAlignment="right" lineBreakMode="headTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="soj-mJ-3y3" userLabel="DF13nsertedDiskLabel">
+                                                    <rect key="frame" x="54" y="11" width="869" height="21"/>
                                                     <color key="tintColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kut-sx-3Td" userLabel="DF3Switch">
+                                                    <rect key="frame" x="934" y="6" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="toggleDF3Switch" destination="fDF-e7-E6W" eventType="touchUpInside" id="3jk-UK-xPX"/>
+                                                    </connections>
+                                                </switch>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="trailingMargin" secondItem="soj-mJ-3y3" secondAttribute="trailing" constant="5" id="1jp-RQ-q7Z"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="soj-mJ-3y3" secondAttribute="trailing" constant="60" id="1jp-RQ-q7Z"/>
                                                 <constraint firstItem="WPl-cA-X9c" firstAttribute="leading" secondItem="Fm8-9r-luR" secondAttribute="leadingMargin" constant="5" id="6Ns-Ib-cmG"/>
+                                                <constraint firstAttribute="centerY" secondItem="kut-sx-3Td" secondAttribute="centerY" id="IDz-kk-L2l"/>
                                                 <constraint firstAttribute="centerY" secondItem="WPl-cA-X9c" secondAttribute="centerY" id="QcE-RH-wPY"/>
                                                 <constraint firstAttribute="centerY" secondItem="soj-mJ-3y3" secondAttribute="centerY" id="RI9-XD-NRb"/>
-                                                <constraint firstItem="soj-mJ-3y3" firstAttribute="leading" secondItem="Fm8-9r-luR" secondAttribute="leadingMargin" constant="38" id="dXv-C9-BW7"/>
+                                                <constraint firstItem="soj-mJ-3y3" firstAttribute="leading" secondItem="Fm8-9r-luR" secondAttribute="leadingMargin" constant="46" id="dXv-C9-BW7"/>
+                                                <constraint firstItem="kut-sx-3Td" firstAttribute="trailing" secondItem="Fm8-9r-luR" secondAttribute="trailingMargin" id="ePa-Um-Ti7"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -430,7 +454,7 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Autoload Config" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nAj-ku-J0t">
                                                     <rect key="frame" x="12" y="11" width="137" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8pu-T2-h7e">
@@ -456,7 +480,7 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Assign Diskfiles" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WOH-9z-5fB">
                                                     <rect key="frame" x="11" y="11" width="132" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -475,7 +499,7 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Current Config" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ms8-jL-60w">
                                                     <rect key="frame" x="12" y="11" width="118" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Config Name" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Yc-d0-1J1">
@@ -505,7 +529,7 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Save/Restore State" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QLu-PW-ADg">
                                                     <rect key="frame" x="15" y="11" width="154" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -524,7 +548,7 @@
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Reset Amiga" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IZT-FH-jk7">
                                                     <rect key="frame" x="11" y="11" width="102" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -554,8 +578,11 @@
                         <outlet property="configurationname" destination="6Yc-d0-1J1" id="VIy-bu-T7q"/>
                         <outlet property="df0" destination="620-hp-l7l" id="1d7-6X-rQs"/>
                         <outlet property="df1" destination="Wyq-9t-jBF" id="rKd-D9-I8Q"/>
+                        <outlet property="df1Switch" destination="Nr6-vh-K16" id="5Eg-jD-HH3"/>
                         <outlet property="df2" destination="Rhj-tQ-Zya" id="AMI-Jm-ocX"/>
+                        <outlet property="df2Switch" destination="f2Q-d6-qne" id="hkn-U9-rss"/>
                         <outlet property="df3" destination="soj-mJ-3y3" id="Me4-8D-PQV"/>
+                        <outlet property="df3Switch" destination="kut-sx-3Td" id="HwV-Hh-hpZ"/>
                         <outlet property="swautoloadconfig" destination="8pu-T2-h7e" id="QNe-ue-6Qy"/>
                         <segue destination="fbF-EZ-ckx" kind="show" identifier="SelectDisk" id="cfj-R0-Oey"/>
                         <segue destination="35x-lU-B56" kind="show" identifier="AssignDiskfiles" id="FAe-3z-c5O"/>

--- a/iUAE.xcodeproj/project.pbxproj
+++ b/iUAE.xcodeproj/project.pbxproj
@@ -1263,6 +1263,8 @@
 		97EF968D1538771F001C01E6 /* icon@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 97EF963F1538771F001C01E6 /* icon@2x.png */; };
 		97EF96A31538771F001C01E6 /* StoogesEmulationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 97EF96571538771F001C01E6 /* StoogesEmulationViewController.m */; };
 		BE0921FF1B343D810058D9F2 /* DiskDriveService.mm in Sources */ = {isa = PBXBuildFile; fileRef = BE0921FE1B343D810058D9F2 /* DiskDriveService.mm */; };
+		BE52EFAA1B4FC9B8008E15E6 /* ResetController.m in Sources */ = {isa = PBXBuildFile; fileRef = BE52EFA61B4FC9B8008E15E6 /* ResetController.m */; };
+		BE52EFAB1B4FC9B8008E15E6 /* DriveState.m in Sources */ = {isa = PBXBuildFile; fileRef = BE52EFA81B4FC9B8008E15E6 /* DriveState.m */; };
 		E18F65E7154CAD470073642F /* Bazooka.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E18F65E6154CAD470073642F /* Bazooka.ttf */; };
 		E18F65EB154CB6960073642F /* intro_5.png in Resources */ = {isa = PBXBuildFile; fileRef = E18F65E8154CB6950073642F /* intro_5.png */; };
 		E18F65EC154CB6960073642F /* intro_5@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E18F65E9154CB6950073642F /* intro_5@2x.png */; };
@@ -2094,6 +2096,10 @@
 		97EF96571538771F001C01E6 /* StoogesEmulationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StoogesEmulationViewController.m; sourceTree = "<group>"; };
 		BE0921FD1B343D810058D9F2 /* DiskDriveService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DiskDriveService.h; sourceTree = "<group>"; };
 		BE0921FE1B343D810058D9F2 /* DiskDriveService.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = DiskDriveService.mm; sourceTree = "<group>"; };
+		BE52EFA61B4FC9B8008E15E6 /* ResetController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ResetController.m; sourceTree = "<group>"; };
+		BE52EFA71B4FC9B8008E15E6 /* ResetController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResetController.h; sourceTree = "<group>"; };
+		BE52EFA81B4FC9B8008E15E6 /* DriveState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DriveState.m; sourceTree = "<group>"; };
+		BE52EFA91B4FC9B8008E15E6 /* DriveState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DriveState.h; sourceTree = "<group>"; };
 		E18F65E6154CAD470073642F /* Bazooka.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Bazooka.ttf; sourceTree = "<group>"; };
 		E18F65E8154CB6950073642F /* intro_5.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = intro_5.png; sourceTree = "<group>"; };
 		E18F65E9154CB6950073642F /* intro_5@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "intro_5@2x.png"; sourceTree = "<group>"; };
@@ -2726,6 +2732,8 @@
 		05BC1B1910734C0700EABC6E /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				BE52EFA61B4FC9B8008E15E6 /* ResetController.m */,
+				BE52EFA71B4FC9B8008E15E6 /* ResetController.h */,
 				7EB0177E1B0921B000C74B9D /* SettingsSelectKeyViewController.h */,
 				7EB0177F1B0921B000C74B9D /* SettingsSelectKeyViewController.m */,
 				7EB017741B09164900C74B9D /* StateFileManager.m */,
@@ -2756,6 +2764,8 @@
 				7E3C13E41A51F16600534164 /* SettingsGeneralController.mm */,
 				BE0921FD1B343D810058D9F2 /* DiskDriveService.h */,
 				BE0921FE1B343D810058D9F2 /* DiskDriveService.mm */,
+				BE52EFA81B4FC9B8008E15E6 /* DriveState.m */,
+				BE52EFA91B4FC9B8008E15E6 /* DriveState.h */,
 			);
 			name = Settings;
 			sourceTree = "<group>";
@@ -4748,6 +4758,7 @@
 				05BC1AF61073448200EABC6E /* EMUFileGroup.m in Sources */,
 				05BC1AF71073448200EABC6E /* EMUFileInfo.m in Sources */,
 				05BC1AF91073448200EABC6E /* EMUROMBrowserViewController.mm in Sources */,
+				BE52EFAB1B4FC9B8008E15E6 /* DriveState.m in Sources */,
 				0585D55F1091640900C1E4C1 /* VirtualKeyboard.m in Sources */,
 				0585D5621091653E00C1E4C1 /* KeyView.m in Sources */,
 				050C393D12C31B24000CE512 /* Disa.c in Sources */,
@@ -4788,6 +4799,7 @@
 				978550FA153A3F2E00580B91 /* DisplayView.m in Sources */,
 				978550FD153A3F2E00580B91 /* ImageUtils.m in Sources */,
 				7E7E522A1A533C8F003E03E7 /* SettingsController.m in Sources */,
+				BE52EFAA1B4FC9B8008E15E6 /* ResetController.m in Sources */,
 				7EAA9DCC192541D400541BE1 /* PMCustomKeyboard.m in Sources */,
 				97855100153A3F2E00580B91 /* NoEffect.m in Sources */,
 				97855103153A3F2E00580B91 /* OGLDisplay.m in Sources */,

--- a/iUAEParents/MainEmulationViewController.h
+++ b/iUAEParents/MainEmulationViewController.h
@@ -24,10 +24,11 @@
 #import "DynamicLandscapeControls.h"
 #import "TouchHandlerViewClassic.h"
 #import "InputControllerView.h"
+#import "ResetController.h"
 
 @class VirtualKeyboard;
 
-@interface MainEmulationViewController : BaseEmulationViewController<AnimatedImageSequenceDelegate, UIWebViewDelegate, UINavigationControllerDelegate> {
+@interface MainEmulationViewController : BaseEmulationViewController<AnimatedImageSequenceDelegate, ResetDelegate, UIWebViewDelegate, UINavigationControllerDelegate> {
     VirtualKeyboard				*vKeyboard;
     FloatPanel *fullscreenPanel;
     bool keyboardactive;

--- a/iUAEParents/Settings.h
+++ b/iUAEParents/Settings.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "DriveState.h"
 
 @interface Settings : NSObject
 
@@ -20,6 +21,7 @@
 @property (nonatomic, readwrite, assign) BOOL showStatus;
 @property (nonatomic, readwrite, assign) NSString *configurationName;
 @property (nonatomic, readwrite, assign) NSArray *configurations;
+@property (nonatomic, readwrite, assign) DriveState *driveState;
 
 /**
  * Returns YES if this is the very first time that the settings are initialized (the firs time the app runs).

--- a/iUAEParents/Settings.mm
+++ b/iUAEParents/Settings.mm
@@ -38,6 +38,10 @@ static NSString *const kStretchScreenKey = @"_stretchscreen";
 static NSString *const kShowStatusKey = @"_showstatus";
 static NSString *const kInsertedFloppiesKey = @"insertedfloppies";
 
+static NSString *const kDf1EnabledKey = @"df1Enabled";
+static NSString *const kDf2EnabledKey = @"df2Enabled";
+static NSString *const kDf3EnabledKey = @"df3Enabled";
+
 extern int mainMenu_showStatus;
 extern int mainMenu_ntsc;
 extern int mainMenu_stretchscreen;
@@ -72,6 +76,7 @@ static NSString *configurationname;
     {
         [defaults setBool:TRUE forKey:kAppSettingsInitializedKey];
         self.autoloadConfig = FALSE;
+        self.driveState = [DriveState getAllEnabled];
         [defaults setObject:@"General" forKey:kConfigurationNameKey];
     }
     return isFirstInitialization;
@@ -165,6 +170,20 @@ static NSString *configurationname;
 
 - (void)setConfigurations:(NSArray *)configurations {
     [self setObject:configurations forKey:kConfigurationsKey];
+}
+
+- (DriveState *)driveState {
+    DriveState *driveState = [[[DriveState alloc] init] autorelease];
+    driveState.df1Enabled = [self boolForKey:kDf1EnabledKey];
+    driveState.df2Enabled = [self boolForKey:kDf2EnabledKey];
+    driveState.df3Enabled = [self boolForKey:kDf3EnabledKey];
+    return driveState;
+}
+
+- (void)setDriveState:(DriveState *)driveState {
+    [self setBool:driveState.df1Enabled forKey:kDf1EnabledKey];
+    [self setBool:driveState.df2Enabled forKey:kDf2EnabledKey];
+    [self setBool:driveState.df3Enabled forKey:kDf3EnabledKey];
 }
 
 - (void)setBool:(BOOL)value forKey:(NSString *)settingitemname {

--- a/uae4all_gp2x_0.7.2a/src/disk.cpp
+++ b/uae4all_gp2x_0.7.2a/src/disk.cpp
@@ -71,7 +71,8 @@ static int floppy_speed = NORMAL_FLOPPY_SPEED;
  */
 
 static int side, direction, writing;
-static uae_u8 selected = 15, disabled=0;
+static uae_u8 selected = 15;
+uae_u8 disabled=0;
 
 static uae_u8 *writebuffer[544 * 22];
 

--- a/uae4all_gp2x_0.7.2a/src/include/options.h
+++ b/uae4all_gp2x_0.7.2a/src/include/options.h
@@ -37,6 +37,8 @@ extern unsigned prefs_chipmem_size;
 extern int prefs_gfx_framerate, changed_gfx_framerate;
 extern int m68k_speed;
 
+extern uae_u8 disabled;
+
 
 #define PREFS_GFX_WIDTH 320
 #define PREFS_GFX_HEIGHT 240


### PR DESCRIPTION
Hi @emufreak,

This change adds switches next to df1-df3 so that they can be disabled.  I am not 100% sure I did this the right way but it seems to work.  
The state of the drives is not persisted, that would require additional work to interact with the code in disk.cpp.  I think that's ok for now - in most cases it is fine to leave all drives on anyway.

Regards -
