### PR TITLE
Added motion controller as an alternative to virtual touch dpad.

### DIFF
--- a/Classes/InputControllerView.mm
+++ b/Classes/InputControllerView.mm
@@ -27,6 +27,7 @@
 #import "KeyButtonViewHandler.h"
 #import "MultiPeerconnectivityController.h"
 #import "MPCConnectionStates.h"
+#import "VPadMotionController.h"
 
 
 InputControllerView *sharedInstance;
@@ -488,6 +489,8 @@ extern MPCStateType mainMenu_servermode;
 }
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
+    if ([VPadMotionController isActive]){return;}
+    
 	UITouch *touch = [touches anyObject];
 	_stickCenter = [touch locationInView:self];
 	_stickVector->x = _stickVector->y = 0;
@@ -496,13 +499,17 @@ extern MPCStateType mainMenu_servermode;
 }
 
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {	
-	UITouch *touch = [touches anyObject];
+	if ([VPadMotionController isActive]){return;}
+    
+    UITouch *touch = [touches anyObject];
 	_stickLocation = [touch locationInView:self];
 	_stickVector->UpdateFromPoints(_stickCenter, _stickLocation);
 	[self calculateDPadState];
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
+    if ([VPadMotionController isActive]){return;}
+    
     _clickedscreen = YES;
 	_stickVector->x = _stickVector->y = 0;
 	[self setDPadState:DPadCenter];

--- a/Classes/SettingsJoypadVpadController.h
+++ b/Classes/SettingsJoypadVpadController.h
@@ -9,14 +9,28 @@
 #import <UIKit/UIKit.h>
 #import "VPadLeftOrRight.h"
 #import "SettingsJoypadStyle.h"
+#import "VPadTouchOrGyro.h"
 
-@interface SettingsJoypadVpadController : UITableViewController <SelectVpadPosDelegate, SelectVPadStyleDelegate>
+@interface SettingsJoypadVpadController : UITableViewController <SelectVpadPosDelegate, SelectVPadStyleDelegate, SelectVpadDirectionDelegate>
 
 @property (retain, nonatomic) IBOutlet UITableViewCell *Joypadstyle;
 @property (retain, nonatomic) IBOutlet UITableViewCell *LeftorRight;
+@property (retain, nonatomic) IBOutlet UITableViewCell *DPadMode;
+
+@property (retain, nonatomic) IBOutlet UITableViewCell *GyroInfo;
+@property (retain, nonatomic) IBOutlet UITableViewCell *GyroCalibration;
+@property (retain, nonatomic) IBOutlet UITableViewCell *GyroToggleUpDown;
+@property (retain, nonatomic) IBOutlet UITableViewCell *GyroSensitivity;
+
 
 - (IBAction)toggleShowButtonTouch:(id)sender;
 @property (retain, nonatomic) IBOutlet UISwitch *swShowButtonTouch;
+
+- (IBAction)toggleGyroUpDown:(id)sender;
+@property (retain, nonatomic) IBOutlet UISwitch *swGyroUpDown;
+
+- (IBAction)gyroSensitivityChanged:(UISlider *)sender;
+@property (retain, nonatomic) IBOutlet UISlider *sliderGyroSensitivity;
 
 @end
 

--- a/Classes/VPadTouchOrGyro.h
+++ b/Classes/VPadTouchOrGyro.h
@@ -1,0 +1,37 @@
+//
+//  VPadTouchOrGyro.h
+//  iUAE
+//
+//  Created by MrStargazer on 02.03.16.
+//
+//
+//  iUAE is free software: you may copy, redistribute
+//  and/or modify it under the terms of the GNU General Public License as
+//  published by the Free Software Foundation, either version 2 of the
+//  License, or (at your option) any later version.
+//
+//  This file is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  General Public License for more details.
+//
+
+#import <UIKit/UIKit.h>
+
+
+@protocol SelectVpadDirectionDelegate
+- (void)didSelectVPadDirection:(NSString *)strType;
+@end
+
+@interface VPadTouchOrGyro : UITableViewController
+
+@property (retain, nonatomic) IBOutlet UITableViewCell *cellTouch;
+@property (retain, nonatomic) IBOutlet UITableViewCell *cellGyro;
+
+
+
+@property (nonatomic, assign) id<SelectVpadDirectionDelegate>	delegate;
+
+- (void) tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath;
+
+@end

--- a/Classes/VPadTouchOrGyro.m
+++ b/Classes/VPadTouchOrGyro.m
@@ -1,0 +1,63 @@
+//
+//  VPadDirections.m
+//  iUAE
+//
+//  Created by MrStargazer on 02.03.16.
+//
+//
+
+
+#import "VPadTouchOrGyro.h"
+#import "Settings.h"
+
+
+@implementation VPadTouchOrGyro {
+    Settings *_settings;
+}
+
+static NSString *const kDPadModeTouch = @"Touch";
+static NSString *const kDPadModeMotion = @"Motion";
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    _settings = [[Settings alloc] init];
+    
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+
+    _cellTouch.accessoryType = _settings.DPadModeIsTouch ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+    _cellGyro.accessoryType = _settings.DPadModeIsMotion ? UITableViewCellAccessoryCheckmark : UITableViewCellAccessoryNone;
+    
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+}
+
+- (void) tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath{
+    
+    if  (indexPath.row == 0) {
+        [self.delegate didSelectVPadDirection: kDPadModeTouch];
+    }
+    else if (indexPath.row == 1){
+        [self.delegate didSelectVPadDirection: kDPadModeMotion];
+    }
+    else {
+        // there should be only two rows.
+    }
+    
+    [self.navigationController popViewControllerAnimated:YES];
+}
+
+
+- (void)dealloc
+{
+    [_cellGyro release];
+    [_cellTouch release];
+    [_settings release];
+    [super dealloc];
+}
+
+@end

--- a/Storyboard.storyboard
+++ b/Storyboard.storyboard
@@ -1246,8 +1246,136 @@
                                             <segue destination="3LA-WS-AAY" kind="show" identifier="SelectLeftOrRight" id="6SL-ek-zOw"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="8L1-ht-bOG" style="IBUITableViewCellStyleDefault" id="C9h-AB-jHu">
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Ttp-SR-MJS" detailTextLabel="z9f-MU-eRb" style="IBUITableViewCellStyleValue1" id="irU-Gz-OhY" userLabel="DPad Cell">
                                         <rect key="frame" x="0.0" y="187" width="1024" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="irU-Gz-OhY" id="Pda-IY-o0r">
+                                            <rect key="frame" x="0.0" y="0.0" width="810" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="DPad Mode" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Ttp-SR-MJS" userLabel="DPad">
+                                                    <rect key="frame" x="196" y="12" width="85" height="20"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="z9f-MU-eRb">
+                                                    <rect key="frame" x="768" y="12" width="42" height="20"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="DTi-e3-4vT" kind="show" identifier="SelectDPadMode" id="PzY-34-IPl"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="gcL-rf-u2f" detailTextLabel="KCk-VD-2h1" style="IBUITableViewCellStyleValue1" id="CmW-J5-ndt" userLabel="Gyro Info Cell">
+                                        <rect key="frame" x="0.0" y="231" width="1024" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="CmW-J5-ndt" id="tPE-eE-SL7">
+                                            <rect key="frame" x="0.0" y="0.0" width="1024" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Gyro Info" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="gcL-rf-u2f">
+                                                    <rect key="frame" x="196" y="12" width="67" height="20"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="KCk-VD-2h1">
+                                                    <rect key="frame" x="786" y="12" width="42" height="20"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="atJ-2q-Yga" style="IBUITableViewCellStyleDefault" id="YPJ-if-jlc" userLabel="Gyro Calibration Cell">
+                                        <rect key="frame" x="0.0" y="275" width="1024" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="YPJ-if-jlc" id="FG3-Sb-unX">
+                                            <rect key="frame" x="0.0" y="0.0" width="1024" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Calibrate Gyro" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="atJ-2q-Yga">
+                                                    <rect key="frame" x="196" y="0.0" width="632" height="43"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="VCX-lb-cz6" style="IBUITableViewCellStyleDefault" id="0Tj-HW-Pv7" userLabel="Gyro Toggle Up Down Cell">
+                                        <rect key="frame" x="0.0" y="319" width="1024" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="0Tj-HW-Pv7" id="3tf-YJ-G2y">
+                                            <rect key="frame" x="0.0" y="0.0" width="1024" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Toggle Gyro Up Down Directions" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="VCX-lb-cz6">
+                                                    <rect key="frame" x="196" y="0.0" width="632" height="43"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wcK-Jy-J1N">
+                                                    <rect key="frame" x="962" y="6" width="51" height="31"/>
+                                                    <connections>
+                                                        <action selector="toggleGyroUpDown:" destination="lsI-FR-9UZ" eventType="touchUpInside" id="QJQ-UY-GNs"/>
+                                                    </connections>
+                                                </switch>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailingMargin" secondItem="wcK-Jy-J1N" secondAttribute="trailing" constant="-2" id="Fz7-0O-ogm"/>
+                                                <constraint firstItem="wcK-Jy-J1N" firstAttribute="centerY" secondItem="VCX-lb-cz6" secondAttribute="centerY" id="SJD-hb-od7"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="K24-7B-pxm" style="IBUITableViewCellStyleDefault" id="4YU-GO-iKb" userLabel="Gyro Sensitivity Cell">
+                                        <rect key="frame" x="0.0" y="363" width="1024" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="4YU-GO-iKb" id="OUT-me-cjx">
+                                            <rect key="frame" x="0.0" y="0.0" width="1024" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.10000000000000001" minValue="0.050000000000000003" maxValue="0.25" translatesAutoresizingMaskIntoConstraints="NO" id="yk0-18-rQZ">
+                                                    <rect key="frame" x="485" y="6" width="336" height="31"/>
+                                                    <accessibility key="accessibilityConfiguration">
+                                                        <accessibilityTraits key="traits" button="YES"/>
+                                                    </accessibility>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="250" id="8NI-GN-9uc"/>
+                                                    </constraints>
+                                                    <connections>
+                                                        <action selector="gyroSensitivityChanged:" destination="lsI-FR-9UZ" eventType="valueChanged" id="3Vx-Sc-hlm"/>
+                                                    </connections>
+                                                </slider>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Gyro Sensitivity" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="200" id="K24-7B-pxm">
+                                                    <rect key="frame" x="196" y="0.0" width="632" height="43"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="yk0-18-rQZ" firstAttribute="centerX" secondItem="K24-7B-pxm" secondAttribute="centerX" constant="100" id="6Nh-f6-ZyV"/>
+                                                <constraint firstItem="yk0-18-rQZ" firstAttribute="centerY" secondItem="K24-7B-pxm" secondAttribute="centerY" id="J6b-uX-hzS"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="8L1-ht-bOG" style="IBUITableViewCellStyleDefault" id="C9h-AB-jHu">
+                                        <rect key="frame" x="0.0" y="407" width="1024" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="C9h-AB-jHu" id="Gin-9t-mea">
                                             <rect key="frame" x="0.0" y="0.0" width="1024" height="43"/>
@@ -1282,8 +1410,15 @@
                         </connections>
                     </tableView>
                     <connections>
+                        <outlet property="DPadMode" destination="irU-Gz-OhY" id="Hwj-he-BcM"/>
+                        <outlet property="GyroCalibration" destination="YPJ-if-jlc" id="oEG-Ha-2gR"/>
+                        <outlet property="GyroInfo" destination="CmW-J5-ndt" id="RtO-Lf-J34"/>
+                        <outlet property="GyroSensitivity" destination="4YU-GO-iKb" id="LRT-F3-K3I"/>
+                        <outlet property="GyroToggleUpDown" destination="0Tj-HW-Pv7" id="zwJ-LY-usj"/>
                         <outlet property="Joypadstyle" destination="5Tj-d4-6Ii" id="8qM-sE-JvE"/>
                         <outlet property="LeftorRight" destination="dSL-oe-PoQ" id="mvp-In-fRe"/>
+                        <outlet property="sliderGyroSensitivity" destination="yk0-18-rQZ" id="TGI-IW-dUT"/>
+                        <outlet property="swGyroUpDown" destination="wcK-Jy-J1N" id="hBg-wK-2eB"/>
                         <outlet property="swShowButtonTouch" destination="Fup-me-bbF" id="NUA-fX-lYv"/>
                     </connections>
                 </tableViewController>
@@ -2417,6 +2552,76 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ljs-VL-kfQ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1173" y="3397"/>
+        </scene>
+        <!--DPad Mode Scene-->
+        <scene sceneID="VX3-qr-sE7">
+            <objects>
+                <tableViewController id="DTi-e3-4vT" userLabel="DPad Mode Scene" customClass="VPadTouchOrGyro" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="H8i-60-gdL">
+                        <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <sections>
+                            <tableViewSection id="aU6-OR-AXs">
+                                <cells>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="checkmark" indentationWidth="10" textLabel="UoZ-LU-QJI" style="IBUITableViewCellStyleDefault" id="GLH-Xs-bC2" userLabel="Cell Touch">
+                                        <rect key="frame" x="0.0" y="64" width="1024" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="GLH-Xs-bC2" id="TvK-sg-lYD">
+                                            <rect key="frame" x="0.0" y="0.0" width="804" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Touch" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UoZ-LU-QJI">
+                                                    <rect key="frame" x="196" y="0.0" width="608" height="43"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="checkmark" indentationWidth="10" textLabel="ztw-AX-ApA" style="IBUITableViewCellStyleDefault" id="obI-nY-gmt" userLabel="Cell Gyro">
+                                        <rect key="frame" x="0.0" y="108" width="1024" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="obI-nY-gmt" id="lGO-AX-sck">
+                                            <rect key="frame" x="0.0" y="0.0" width="804" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Gyro" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ztw-AX-ApA">
+                                                    <rect key="frame" x="196" y="0.0" width="608" height="43"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KLh-Hj-MIA">
+                                        <rect key="frame" x="0.0" y="152" width="1024" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KLh-Hj-MIA" id="hNM-4W-wpS">
+                                            <rect key="frame" x="0.0" y="0.0" width="1024" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="DTi-e3-4vT" id="SWA-Tn-pMg"/>
+                            <outlet property="delegate" destination="DTi-e3-4vT" id="ecf-Or-Dpr"/>
+                        </connections>
+                    </tableView>
+                    <connections>
+                        <outlet property="cellGyro" destination="obI-nY-gmt" id="Jcp-Li-jVr"/>
+                        <outlet property="cellTouch" destination="GLH-Xs-bC2" id="3zZ-LI-4Zi"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="7ZZ-yR-PxN" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="6932" y="2422"/>
         </scene>
     </scenes>
     <resources>

--- a/TargetSpecific/SingleView/BaseNavigationController.mm
+++ b/TargetSpecific/SingleView/BaseNavigationController.mm
@@ -22,6 +22,7 @@
 //Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
 #import "BaseNavigationController.h"
+#import "VPadMotionController.h"
 
 @interface BaseNavigationController ()
 
@@ -66,7 +67,7 @@
 }
 
 - (BOOL)shouldAutorotate {
-    return YES;
+    return [VPadMotionController isActive]?  NO : YES;
 }
 
 @end

--- a/iUAE.xcodeproj/project.pbxproj
+++ b/iUAE.xcodeproj/project.pbxproj
@@ -1287,6 +1287,9 @@
 		E18F65EB154CB6960073642F /* intro_5.png in Resources */ = {isa = PBXBuildFile; fileRef = E18F65E8154CB6950073642F /* intro_5.png */; };
 		E18F65EC154CB6960073642F /* intro_5@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E18F65E9154CB6950073642F /* intro_5@2x.png */; };
 		E18F65ED154CB6960073642F /* intro_5~ipad.png in Resources */ = {isa = PBXBuildFile; fileRef = E18F65EA154CB6950073642F /* intro_5~ipad.png */; };
+		E937D8A71CB58BC9008DCC27 /* CoreMotion.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E937D8A61CB58BC9008DCC27 /* CoreMotion.framework */; };
+		E937D8AA1CB58C50008DCC27 /* VPadMotionController.mm in Sources */ = {isa = PBXBuildFile; fileRef = E937D8A91CB58C50008DCC27 /* VPadMotionController.mm */; };
+		E937D8B01CB58CE3008DCC27 /* VPadTouchOrGyro.m in Sources */ = {isa = PBXBuildFile; fileRef = E937D8AF1CB58CE3008DCC27 /* VPadTouchOrGyro.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -2164,6 +2167,11 @@
 		E18F65E8154CB6950073642F /* intro_5.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = intro_5.png; sourceTree = "<group>"; };
 		E18F65E9154CB6950073642F /* intro_5@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "intro_5@2x.png"; sourceTree = "<group>"; };
 		E18F65EA154CB6950073642F /* intro_5~ipad.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "intro_5~ipad.png"; sourceTree = "<group>"; };
+		E937D8A61CB58BC9008DCC27 /* CoreMotion.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMotion.framework; path = System/Library/Frameworks/CoreMotion.framework; sourceTree = SDKROOT; };
+		E937D8A81CB58C4F008DCC27 /* VPadMotionController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VPadMotionController.h; path = iUAEParents/VPadMotionController.h; sourceTree = "<group>"; };
+		E937D8A91CB58C50008DCC27 /* VPadMotionController.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = VPadMotionController.mm; path = iUAEParents/VPadMotionController.mm; sourceTree = "<group>"; };
+		E937D8AE1CB58CE3008DCC27 /* VPadTouchOrGyro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VPadTouchOrGyro.h; sourceTree = "<group>"; };
+		E937D8AF1CB58CE3008DCC27 /* VPadTouchOrGyro.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VPadTouchOrGyro.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2185,6 +2193,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E937D8A71CB58BC9008DCC27 /* CoreMotion.framework in Frameworks */,
 				9064AD551C7D09FA004CAE28 /* MultipeerConnectivity.framework in Frameworks */,
 				7EB372EA1A0FC8DE001B460A /* GameController.framework in Frameworks */,
 				7EA7D6F1187B480C0092FC2F /* AudioToolbox.framework in Frameworks */,
@@ -2787,6 +2796,8 @@
 		05BC1B1910734C0700EABC6E /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				E937D8AE1CB58CE3008DCC27 /* VPadTouchOrGyro.h */,
+				E937D8AF1CB58CE3008DCC27 /* VPadTouchOrGyro.m */,
 				7E079CBF1A81594B00EC0DE4 /* AddConfigurationViewController.h */,
 				7E079CC01A81594B00EC0DE4 /* AddConfigurationViewController.m */,
 				BE6086D71C2CF5AC008E668B /* adfresolver.h */,
@@ -2892,6 +2903,8 @@
 		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
+				E937D8A81CB58C4F008DCC27 /* VPadMotionController.h */,
+				E937D8A91CB58C50008DCC27 /* VPadMotionController.mm */,
 				9064AD601C7F7982004CAE28 /* MultiPeerConnectivityController.h */,
 				9064AD611C7F7982004CAE28 /* MultiPeerConnectivityController.mm */,
 				9064AD621C7F7982004CAE28 /* MPCConnectionStates.h */,
@@ -2950,6 +2963,7 @@
 		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E937D8A61CB58BC9008DCC27 /* CoreMotion.framework */,
 				9064AD541C7D09FA004CAE28 /* MultipeerConnectivity.framework */,
 				7EB372E91A0FC8DE001B460A /* GameController.framework */,
 				976877751534B2D20077B654 /* AudioToolbox.framework */,
@@ -4864,6 +4878,7 @@
 				0552BD540F3D797C005B30DF /* vkbd.cpp in Sources */,
 				BEE41BD61B4784AC00CE487D /* ioapi.c in Sources */,
 				BEE41BD31B4784AC00CE487D /* zip.c in Sources */,
+				E937D8B01CB58CE3008DCC27 /* VPadTouchOrGyro.m in Sources */,
 				0552BD550F3D797C005B30DF /* writelog.cpp in Sources */,
 				7E54BB201AA3362E0054F6B2 /* MFIControllerReaderView.mm in Sources */,
 				7EA2BCA1188B0EF6003DCE10 /* SingleWindowAppDelegate.mm in Sources */,
@@ -4902,6 +4917,7 @@
 				7EF97ABD1A7586E7002CC332 /* SelectConfigurationViewController.m in Sources */,
 				978550C7153A3F2E00580B91 /* SDL_events.c in Sources */,
 				7EB017651B09115900C74B9D /* StateManagementController.mm in Sources */,
+				E937D8AA1CB58C50008DCC27 /* VPadMotionController.mm in Sources */,
 				7E2A59B11B052C3300C802E0 /* SettingsJoypadController.m in Sources */,
 				978550CA153A3F2E00580B91 /* SDL_mouse_c.c in Sources */,
 				978550CD153A3F2E00580B91 /* ButtonStates.m in Sources */,

--- a/iUAEParents/MainEmulationViewController.mm
+++ b/iUAEParents/MainEmulationViewController.mm
@@ -36,6 +36,7 @@
 #import "DiskDriveService.h"
 #import <GameController/GameController.h>
 #import "MultiPeerConnectivityController.h"
+#import "VPadMotionController.h"
 
 extern SDL_Joystick *uae4all_joy0, *uae4all_joy1;
 extern void init_joystick();
@@ -128,7 +129,15 @@ extern void uae_reset();
     [_mouseHandler reloadMouseSettings];
     [_joyController reloadJoypadSettings];
     
+    if (joyactive && _settings.DPadModeIsMotion){
+        [VPadMotionController setActive];
+    }
+    
     [mpcController configure: self];
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    [VPadMotionController disable];
 }
 
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
@@ -154,12 +163,14 @@ extern void uae_reset();
     /* Check if function is still needed */
     _joyController.hidden = TRUE;
     joyactive = FALSE;
+    [VPadMotionController disable];
 }
 
 - (void)initializeControls {
     joyactive = FALSE;
     _mouseHandler.hidden = FALSE;
     _joyController.hidden = TRUE;
+    [VPadMotionController disable];
 }
 
 extern  void mousehack_setdontcare_iuae ();
@@ -178,6 +189,15 @@ extern void togglemouse (void);
     //_btnJoypad.tintColor = _btnJoypad.selected ? [UIColor blueColor] : [UIColor blackColor];
     
     _joyController.hidden = !joyactive;
+
+    
+    if (joyactive && _settings.DPadModeIsMotion){
+        [VPadMotionController setActive];
+    }
+    else{
+        [VPadMotionController disable];
+    }
+    
     _mouseHandler.hidden = joyactive;
 
     if (joyactive)

--- a/iUAEParents/Settings.h
+++ b/iUAEParents/Settings.h
@@ -38,6 +38,12 @@ static NSString *const kJoyStyleFourButton = @"FourButton";
 @property (nonatomic, readwrite, assign) BOOL joypadshowbuttontouch;
 @property (nonatomic, readwrite, assign) BOOL keyButtonsEnabled;
 @property (nonatomic, readwrite, assign) NSArray *keyButtonConfigurations;
+@property (nonatomic, readwrite, assign) NSString *dpadTouchOrMotion;
+@property (nonatomic, readonly, assign) BOOL DPadModeIsTouch;
+@property (nonatomic, readonly, assign) BOOL DPadModeIsMotion;
+@property (nonatomic, readwrite, assign) BOOL gyroToggleUpDown;
+@property (nonatomic, readwrite, assign) float gyroSensitivity;
+
 
 - (void)setFloppyConfigurations:(NSArray *)adfPaths;
 - (void)setFloppyConfiguration:(NSString *)adfPath;

--- a/iUAEParents/Settings.mm
+++ b/iUAEParents/Settings.mm
@@ -49,6 +49,10 @@ static NSString *const kSelectedEffectIndexKey = @"_selectedeffectindex";
 static NSString *const kJoypadStyleKey = @"_joypadstyle";
 static NSString *const kJoypadLeftOrRightKey = @"_joypadleftorright";
 static NSString *const kJoypadShowButtonTouchKey = @"_joypadshowbuttontouch";
+static NSString *const kDPadTouchOrMotion = @"_dpadTouchOrMotion";
+
+static NSString *const kGyroToggleUpDown = @"_gyroToggleUpDown";
+static NSString *const kGyroSensitivity = @"_gyroSensitivity";
 
 static NSString *const kDf1EnabledKey = @"df1Enabled";
 static NSString *const kDf2EnabledKey = @"df2Enabled";
@@ -131,6 +135,9 @@ static NSString *configurationname;
     self.joypadstyle =              [self keyExists:kJoypadStyleKey]            ? self.joypadstyle          :   @"FourButton";
     self.joypadleftorright =        [self keyExists:kJoypadLeftOrRightKey]      ? self.joypadleftorright    :   @"Right";
     self.joypadshowbuttontouch =    [self keyExists:kJoypadShowButtonTouchKey]  ? self.joypadshowbuttontouch :  YES;
+    self.dpadTouchOrMotion =        [self keyExists:kDPadTouchOrMotion]         ? self.dpadTouchOrMotion : @"Touch";
+    self.gyroToggleUpDown =         [self keyExists:kGyroToggleUpDown]          ? self.gyroToggleUpDown : NO;
+    self.gyroSensitivity =          [self keyExists:kGyroSensitivity]           ? self.gyroSensitivity : 0.1;
     
     if (![self keyExists:[NSString stringWithFormat:@"_BTN_%d", BTN_A]])
     //Set default values for JoypadKeyconfiguration
@@ -236,8 +243,40 @@ static NSString *configurationname;
     return [self boolForKey:kJoypadShowButtonTouchKey];
 }
 
--(void)setJoypadshowbuttontouch:(BOOL)joypadshowbuttontouch {
+- (void)setJoypadshowbuttontouch:(BOOL)joypadshowbuttontouch {
     [self setBool:joypadshowbuttontouch forKey:kJoypadShowButtonTouchKey];
+}
+
+- (NSString *)dpadTouchOrMotion {
+    return [self stringForKey:kDPadTouchOrMotion];
+}
+
+- (void)setDpadTouchOrMotion:(NSString *)dpadTouchOrMotion {
+    [self setObject:dpadTouchOrMotion forKey:kDPadTouchOrMotion];
+}
+
+- (BOOL)DPadModeIsTouch {
+    return [[self stringForKey:kDPadTouchOrMotion] isEqualToString: @"Touch"];
+}
+
+- (BOOL)DPadModeIsMotion {
+    return [[self stringForKey:kDPadTouchOrMotion]  isEqualToString: @"Motion"];
+}
+
+- (BOOL)gyroToggleUpDown {
+    return [self boolForKey:kGyroToggleUpDown];
+}
+
+- (void)setGyroToggleUpDown:(BOOL)gyroToggleUpDown {
+    [self setBool:gyroToggleUpDown forKey:kGyroToggleUpDown];
+}
+
+- (float)gyroSensitivity {
+    return [self floatForKey:kGyroSensitivity];
+}
+
+- (void)setGyroSensitivity:(float)gyroSensitivity {
+    [self setFloat:gyroSensitivity forKey:kGyroSensitivity];
 }
 
 -(void)setKeyconfiguration:(NSString *)configuredkey Button:(int)button {
@@ -372,6 +411,14 @@ NSString *const kEnabledAttrName = @"enabled";
 
 - (NSInteger)integerForKey:(NSString *)settingitemname {
     return [defaults integerForKey:[self getInternalSettingKey:settingitemname]];
+}
+
+- (float)floatForKey:(NSString *)settingitemname {
+    return [defaults floatForKey:[self getInternalSettingKey:settingitemname]];
+}
+
+- (void)setFloat:(float)value forKey:(NSString *)settingitemname {
+    [defaults setFloat:value forKey:[self getInternalSettingKey:settingitemname]];
 }
 
 - (NSArray *)arrayForKey:(NSString *)settingitemname {

--- a/iUAEParents/VPadMotionController.h
+++ b/iUAEParents/VPadMotionController.h
@@ -1,0 +1,42 @@
+//
+//  VPadMotionController.h
+//  iUAE
+//
+//  Created by MrStargazer on 27.03.16.
+//
+//
+//  iUAE is free software: you may copy, redistribute
+//  and/or modify it under the terms of the GNU General Public License as
+//  published by the Free Software Foundation, either version 2 of the
+//  License, or (at your option) any later version.
+//
+//  This file is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  General Public License for more details.
+//
+
+#ifndef VPadMotionController_h
+#define VPadMotionController_h
+
+#import <CoreMotion/CoreMotion.h>
+
+@interface VPadMotionController : NSObject {
+}
+
+
+//+ (VPadMotionController*)motionController;
+
++ (void) startUpdating;
++ (void) stopUpdating;
++ (void) calibrate;
++ (CMAttitude*) getMotion;
++ (CMAttitude*) referenceAttitude;
++ (BOOL) isActive;
++ (void) setActive;
++ (void) disable;
+
+
+@end
+
+#endif /* VPadMotionController_h */

--- a/iUAEParents/VPadMotionController.mm
+++ b/iUAEParents/VPadMotionController.mm
@@ -1,0 +1,164 @@
+//
+//  VPadMotionController.m
+//  iUAE
+//
+//  Created by MrStargazer on 27.03.16.
+//
+//
+
+#import "VPadMotionController.h"
+#import "touchstick.h"
+#import "CGVector.h"
+#import "CocoaUtility.h"
+#import "SDL_events.h"
+#import "JoypadKey.h"
+#import "Settings.h"
+
+extern CJoyStick g_touchStick;
+
+@implementation VPadMotionController {
+    
+}
+
+static CMAttitude *refAttitude = nil;
+static CMMotionManager *motionController = nil;
+static Settings *settings;
+static BOOL active = NO;
+const float motionUpdateInterval = 1.0/30.0;
+static CJoyStick *TheJoyStick;
+
++ (BOOL) isActive{
+    return active;
+}
+
+// activates motion controlling
++ (void) setActive{
+    active = YES;
+    TheJoyStick = &g_touchStick;
+    [self stopUpdating];
+    motionController.deviceMotionUpdateInterval = motionUpdateInterval;
+    
+    // register for motion updates
+    [motionController startDeviceMotionUpdatesToQueue:[NSOperationQueue currentQueue] withHandler:^(CMDeviceMotion *motionData, NSError *error){
+        [self receiveMotionData:motionData.attitude];
+        if(error){
+            
+            NSLog(@"%@", error);
+        }
+    }];
+    
+    
+}
+
+// receivces frequently motion data and translate it into joystick directions
++ (void) receiveMotionData : (CMAttitude*)currentAttitude{
+    // process data
+    
+    TouchStickDPadState dpadState;
+    float deadZone = settings.gyroSensitivity;
+    BOOL toggleUpDown = settings.gyroToggleUpDown;
+    
+    if (refAttitude != nil){
+        [currentAttitude multiplyByInverseOfAttitude: refAttitude];
+    }
+    
+    if (currentAttitude.pitch < -deadZone && currentAttitude.roll < -deadZone){
+        dpadState = toggleUpDown ? DPadUpRight : DPadDownRight;
+    }
+    else if (currentAttitude.pitch < -deadZone && currentAttitude.roll > deadZone){
+        dpadState = toggleUpDown ? DPadDownRight : DPadUpRight;
+    }
+    else if (currentAttitude.pitch > deadZone && currentAttitude.roll < -deadZone){
+        dpadState = toggleUpDown ? DPadUpLeft : DPadDownLeft;
+    }
+    else if (currentAttitude.pitch > deadZone && currentAttitude.roll > deadZone){
+        dpadState = toggleUpDown ? DPadDownLeft : DPadUpLeft;
+    }
+    else if (currentAttitude.roll > deadZone && ABS(currentAttitude.pitch) < deadZone)
+    {
+
+        dpadState = toggleUpDown ? DPadDown : DPadUp;
+    }
+    else if (currentAttitude.roll < -deadZone && ABS(currentAttitude.pitch) < deadZone){
+        dpadState = toggleUpDown ? DPadUp : DPadDown;
+    }
+    else if (currentAttitude.pitch > deadZone && ABS(currentAttitude.roll) < deadZone){
+        dpadState = DPadLeft;
+    }
+    else if (currentAttitude.pitch < -deadZone && ABS(currentAttitude.roll) < deadZone){
+        dpadState = DPadRight;
+    }
+    else {
+        dpadState = DPadCenter;
+    }
+    
+    TheJoyStick->setDPadStateP0(dpadState);
+    TheJoyStick->setDPadStateP1(dpadState);
+    
+}
+
+// disables motion controlling
++ (void) disable{
+    [self stopUpdating];
+    active = NO;
+}
+
+// interface to apples motion api (CoreMotion)
++ (CMMotionManager*)motionManager {
+    
+    if (motionController != nil){
+        return motionController;
+    }
+ 
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        motionController = [[CMMotionManager alloc] init];
+        settings = [[Settings alloc] init];
+        motionController.deviceMotionUpdateInterval = 1.0/60.0;
+        [motionController startDeviceMotionUpdates];
+        
+    });
+    
+    return motionController;
+}
+
+// returns the reference position set with method calibrate
++ (CMAttitude*)referenceAttitude{
+    return refAttitude;
+}
+
+// starts receiving motion updates
++ (void)startUpdating {
+    if (!self.motionManager.isDeviceMotionActive){
+        [self.motionManager startDeviceMotionUpdates];
+    }
+}
+
+// stops motion controller receiving motion updates
++ (void)stopUpdating {
+    if ([self motionManager].isDeviceMotionActive){
+        [[self motionManager] stopDeviceMotionUpdates];
+    }
+}
+
+// sets der current position of the device as reference for movement
++ (void)calibrate {
+    refAttitude = self.motionManager.deviceMotion.attitude.copy;
+}
+
++ (CMAttitude*)getMotion {
+    CMAttitude *currentAttitude = self.motionManager.deviceMotion.attitude;
+
+    if (refAttitude != nil){
+      [currentAttitude multiplyByInverseOfAttitude: refAttitude];
+    }
+
+    return currentAttitude;
+}
+
+- (void)dealloc {
+    // Should never be called, but just here for clarity really.
+    [super dealloc];
+}
+
+@end


### PR DESCRIPTION
The motion controller lets you control the joystick directions (vdpad) by moving the device around the x- and y axis. All 8 directions from the amiga joystick are supported. As until now the one and four buttons will be used from the virtual joystick.

The new controller can be turned on under the settings for virtual dpad, called DPadMode. If DPadMode  "Motion" is selected,  you can configure and calibrate the controller.

I think this is a first version and there is more to do, but I don't want to wait any longer.
