### PR TITLE
Issue #44: add section to settings to let the user pick a rom file to…

### DIFF
--- a/Classes/CoreSetting.h
+++ b/Classes/CoreSetting.h
@@ -1,0 +1,54 @@
+//  Created by Simon Toens on 11.05.16
+//
+//  iUAE is free software: you may copy, redistribute
+//  and/or modify it under the terms of the GNU General Public License as
+//  published by the Free Software Foundation, either version 2 of the
+//  License, or (at your option) any later version.
+//
+//  This file is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+#import <Foundation/Foundation.h>
+
+/**
+ * A special setting (property/switch/toggle) that requires an emulator reset to take effect.  For example, the rom being used.
+ *
+ * This is an abstract class.
+ */
+@interface CoreSetting : NSObject <NSCopying>
+
+/**
+ * Updates the value of this setting (persists the new value).
+ */
+- (void)toggleFromOldValue:(NSString *)oldValue toNewValue:(NSString *)newValue;
+
+/**
+ * Returns YES if the setting has a new value, but a reset has not happened yet (ie the value has not taken effect).
+ */
+- (BOOL)hasUnappliedValue;
+
+- (instancetype)init __unavailable;
+
+@end
+
+@interface RomCoreSetting : CoreSetting
+
+@end
+
+
+@interface CoreSettings : NSObject
+
+/**
+ * Notifies that the emulator has been reset.
+ */
++ (void)onReset;
+
++ (RomCoreSetting *)romCoreSetting;
+
+@end

--- a/Classes/CoreSetting.m
+++ b/Classes/CoreSetting.m
@@ -1,0 +1,133 @@
+//  Created by Simon Toens on 11.05.16
+//
+//  iUAE is free software: you may copy, redistribute
+//  and/or modify it under the terms of the GNU General Public License as
+//  published by the Free Software Foundation, either version 2 of the
+//  License, or (at your option) any later version.
+//
+//  This file is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+#import "CoreSetting.h"
+#import "Settings.h"
+
+@interface CoreSettingsRegistry : NSObject
+
++ (CoreSettingsRegistry *)sharedRegistry;
+
+@property (nonatomic, readonly) Settings *settings;
+@property (nonatomic, readonly) NSMutableDictionary *settingToOriginalValue;
+
+@end
+
+@implementation CoreSetting {
+    @private
+    CoreSettingsRegistry *_registry;
+    NSString *_settingName;
+}
+
+- (instancetype)initWithName:(NSString *)settingName {
+    if (self = [super init]) {
+        _registry = [CoreSettingsRegistry sharedRegistry];
+        _settingName = [settingName retain];
+    }
+    return self;
+}
+
+- (void)toggleFromOldValue:(NSString *)oldValue toNewValue:(NSString *)newValue {
+    if ([self eq:oldValue to:newValue]) {
+        return;
+    }
+    NSString *originalValue = [_registry.settingToOriginalValue objectForKey:self];
+    if (originalValue) {
+        if ([self eq:newValue to:originalValue]) {
+            [_registry.settingToOriginalValue removeObjectForKey:self];
+        }
+    } else {
+        id o = oldValue ? oldValue : [NSNull null];
+        [_registry.settingToOriginalValue setObject:o forKey:self];
+    }
+    [self persistValue:newValue];
+}
+
+- (BOOL)eq:(id)thing1 to:(id)thing2 {
+    if (!thing1 && !thing2) return YES;
+    if (!thing1 && thing2 == [NSNull null]) return YES;
+    if (thing1 == [NSNull null] && !thing2) return YES;
+    return [thing1 isEqual:thing2];
+}
+
+- (BOOL)hasUnappliedValue {
+    return [_registry.settingToOriginalValue objectForKey:self] != nil;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone {
+    return [self retain];
+}
+
+- (void)persistValue:(id)value {
+    [NSException raise:@"Subclasses must implement" format:@"%@", NSStringFromSelector(_cmd)];
+}
+
+- (NSString *)description {
+    return _settingName;
+}
+
+- (void)dealloc {
+    [_settingName release];
+    [super dealloc];
+}
+
+@end
+
+@implementation RomCoreSetting
+
+- (void)persistValue:(id)value {
+    [CoreSettingsRegistry sharedRegistry].settings.romPath = value;
+}
+
+@end
+
+@implementation CoreSettingsRegistry
+
++ (CoreSettingsRegistry *)sharedRegistry {
+    static CoreSettingsRegistry *registry = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        registry = [[CoreSettingsRegistry alloc] init];
+    });
+    return registry;
+}
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _settings = [[Settings alloc] init];
+        _settingToOriginalValue = [[NSMutableDictionary alloc] init];
+    }
+    return self;
+}
+
+@end
+
+@implementation CoreSettings
+
++ (void)onReset {
+    [[CoreSettingsRegistry sharedRegistry].settingToOriginalValue removeAllObjects];
+}
+
++ (RomCoreSetting *)romCoreSetting {
+    static RomCoreSetting *romCoreSetting = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        romCoreSetting = [[RomCoreSetting alloc] initWithName:@"ROM"];
+    });
+    return romCoreSetting;
+}
+
+@end

--- a/Classes/DiskDriveService.h
+++ b/Classes/DiskDriveService.h
@@ -18,7 +18,7 @@
 #import "DriveState.h"
 
 /**
- * The disk drive service handles interactions with the disk drives.
+ * The disk drive service handles interactions with the disk drives.  Also has some rom related logic.
  *
  * Note that this class uses the emulator state as source of truth, it does not/should not read configuration.
  */
@@ -68,5 +68,15 @@
  * Enables/disables drives as specified in the given driveState instance.
  */
 - (void)setDriveState:(DriveState *)driveState;
+
+/**
+ * Returns the path of the rom file the emulator is currently using.
+ */
+- (NSString *)getRomPath;
+
+/**
+ * Configures the emulator to use the speficied rom.
+ */
+- (void)configureRom:(NSString *)romPath;
 
 @end

--- a/Classes/DiskDriveService.mm
+++ b/Classes/DiskDriveService.mm
@@ -18,6 +18,8 @@
 #import "sysconfig.h"
 #import "sysdeps.h"
 #import "options.h"
+#import "memory.h"
+#import "zfile.h"
 #import "DiskDriveService.h"
 
 @implementation DiskDriveService
@@ -117,6 +119,17 @@
     if (NUM_DRIVES > 3) {
         [self enableDrive:3 enable:driveState.df3Enabled];
     }
+}
+
+- (NSString *)getRomPath {
+    NSString *romPath = [NSString stringWithCString:romfile encoding:[NSString defaultCStringEncoding]];
+    return [romPath length] == 0 ? nil : romPath;
+}
+
+- (void)configureRom:(NSString *)romPath {
+    [romPath getCString:romfile maxLength:sizeof(romfile) encoding:[NSString defaultCStringEncoding]];
+    bReloadKickstart = 1;
+    uae4all_rom_reinit();
 }
 
 @end

--- a/Classes/File Browser/DiskAssociationViewController.mm
+++ b/Classes/File Browser/DiskAssociationViewController.mm
@@ -55,7 +55,7 @@
 	[sections addObject:[[EMUFileGroup alloc] initWithSectionName:@"#"]];
 	
 	EMUBrowser *browser = [[EMUBrowser alloc] init];
-	NSArray *files = [browser getFileInfos];
+	NSArray *files = [browser getAdfFileInfos];
 	for (EMUFileInfo* f in files) {
 		unichar c = [[f fileName] characterAtIndex:0];
 		if (isdigit(c)) {

--- a/Classes/File Browser/EMUBrowser.h
+++ b/Classes/File Browser/EMUBrowser.h
@@ -22,19 +22,25 @@
 
 @interface EMUBrowser : NSObject
 
-/**
- * Returns an array of EMUFileInfo instances for all available files.
- */
-- (NSArray *)getFileInfos;
 
 /**
- * Returns an EMUFileInfo instance for the specified fileName (xyz.adf), or nil if a file with that name does not exist.
+ * Returns an array of EMUFileInfo instances for all available adf files.
  */
-- (EMUFileInfo *)getFileInfo:(NSString *)fileName;
+- (NSArray *)getAdfFileInfos;
 
 /**
- * The extensions of the files this EMUBrowser loads.  Defaults to [adf, ADF].
+ * Returns an array of EMUFileInfo instances for all available files that match the specified extensions (for ex @[adf, ADF]).
  */
-@property (nonatomic, retain) NSArray* extensions;
+- (NSArray *)getFileInfosForExtensions:(NSArray *)extensions;
+
+/**
+ * Returns a EMUFileInfo instance matching the specified file name (for ex xyz.adf), or nil if no match is found.
+ */
+- (EMUFileInfo *)getFileInfoForFileName:(NSString *)fileName;
+
+/**
+ * Returns an array of EMUFileInfo instances for all available files whose names match the specified file names (@[xyz.adf, blah.rom].
+ */
+- (NSArray *)getFileInfosForFileNames:(NSArray *)fileName;
 
 @end

--- a/Classes/File Browser/EMUROMBrowserViewController.h
+++ b/Classes/File Browser/EMUROMBrowserViewController.h
@@ -36,7 +36,7 @@
 	id context;
 }
 
-+ (NSString *)getAdfChangedNotificationName;
++ (NSString *)getFileImportedNotificationName;
 
 @property (nonatomic, retain) NSArray *roms, *indexTitles;
 @property (nonatomic, retain) NSIndexPath *selectedIndexPath;

--- a/Classes/ResetController.m
+++ b/Classes/ResetController.m
@@ -14,9 +14,10 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 
+#import "CoreSetting.h"
 #import "DiskDriveService.h"
-#import "HardDriveService.h"
 #import "EMUFileInfo.h"
+#import "HardDriveService.h"
 #import "ResetController.h"
 
 static NSString *const kSelectHardfileSegue = @"SelectHardfile";
@@ -67,6 +68,7 @@ static NSString *const kNoHardfileText = @"Not Mounted";
 
 - (IBAction)onResetConfirmed {
     [self.delegate didSelectReset:_driveState hardfilePath:_selectedHardfilePath];
+    [CoreSettings onReset];
     [self.navigationController popToRootViewControllerAnimated:YES];
 }
 

--- a/Classes/SettingsGeneralController.h
+++ b/Classes/SettingsGeneralController.h
@@ -27,6 +27,8 @@
 @interface SettingsGeneralController : UITableViewController<SelectRomDelegate, SelectConfigurationDelegate>
 
 @property (readwrite, retain) IBOutlet UISwitch *swautoloadconfig;
+@property (readwrite, retain) IBOutlet UILabel *rom;
+@property (readwrite, retain) IBOutlet UILabel *romWarning;
 @property (readwrite, retain) IBOutlet UILabel *df0;
 @property (readwrite, retain) IBOutlet UILabel *df1;
 @property (readwrite, retain) IBOutlet UILabel *df2;

--- a/Classes/StateManagementController.mm
+++ b/Classes/StateManagementController.mm
@@ -19,6 +19,7 @@
 #include "options.h"
 #include "savestate.h"
 
+#import "CoreSetting.h"
 #import "State.h"
 #import "StateManagementController.h"
 #import "StateFileManager.h"
@@ -172,6 +173,7 @@ static NSString *kSaveStateAlertTitle = @"Save";
     [stateToRestore.path getCString:path maxLength:sizeof(path) encoding:[NSString defaultCStringEncoding]];
     savestate_filename = path;
     savestate_state = STATE_DORESTORE;
+    [CoreSettings onReset]; // restoring a state resets the emulator
     
     // the state restore logic, including inserting the floppy(ies) associated with the state, only runs when exiting settings.  In order to reduce confusion about what
     // floppies are inserted after the state has been restored, exit settings now

--- a/Classes/adfresolver.mm
+++ b/Classes/adfresolver.mm
@@ -25,8 +25,10 @@ const char* get_updated_adf_path(const char *adf_path) {
     if ([adfPath length] > 0) {
         NSString *adfFileName = [adfPath lastPathComponent];
         EMUBrowser *browser = [[[EMUBrowser alloc] init] autorelease];
-        EMUFileInfo *fileInfo = [browser getFileInfo:adfFileName];
-        updatedAdfPath = fileInfo.path;
+        EMUFileInfo *fileInfo = [browser getFileInfoForFileName:adfFileName];
+        if (fileInfo) {
+            updatedAdfPath = fileInfo.path;
+        }
     }
     static char adf[256];
     [updatedAdfPath getCString:adf maxLength:sizeof(adf) encoding:[NSString defaultCStringEncoding]];

--- a/Info.plist
+++ b/Info.plist
@@ -10,7 +10,17 @@
 	<array>
 		<dict>
 			<key>CFBundleTypeName</key>
-			<string>Zipped ADFs</string>
+			<string>Amiga ROM File</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>iUAE.rom</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Zipped Amiga Disk File(s)</string>
 			<key>LSHandlerRank</key>
 			<string>Owner</string>
 			<key>LSItemContentTypes</key>
@@ -28,6 +38,16 @@
 				<string>iUAE.adf</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Amiga Hard Drive File</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>iUAE.hdf</string>
+			</array>
+		</dict>        
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
@@ -82,6 +102,19 @@
 				<string>public.data</string>
 			</array>
 			<key>UTTypeIdentifier</key>
+			<string>iUAE.rom</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<string>rom</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeIdentifier</key>
 			<string>iUAE.zip</string>
 			<key>UTTypeTagSpecification</key>
 			<dict>
@@ -102,6 +135,19 @@
 				<string>adf</string>
 			</dict>
 		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeIdentifier</key>
+			<string>iUAE.hdf</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<string>hdf</string>
+			</dict>
+		</dict>        
 	</array>
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ git submodule init
 git submodule update
 ```
 
-#####ROM
-Use iTunes to copy a rom to your device.  The rom file must be called kick.rom or kick13.rom.  Alternatively you can also add the rom file to the Xcode project when building iUAE.
+#####ROMs
+Use iTunes to copy rom file(s) to your device, or add the roms to the Xcode project when building iUAE.  When the emulator starts up for the first time, it will look for a rom called "kick.rom" or "kick13.rom".  If your rom file has a differnet name or if you want to switch roms, you can use the rom selector in settings;  switching roms requires resetting the emulator.
 
 #####Disk drives
 

--- a/SelectConfigurationViewController.m
+++ b/SelectConfigurationViewController.m
@@ -139,7 +139,7 @@
 
 - (void)deleteConfiguration:(NSIndexPath *)indexPath {
     EMUBrowser *browser = [[EMUBrowser alloc] init];
-    NSArray *files = [browser getFileInfos];
+    NSArray *files = [browser getAdfFileInfos];
     NSString *configdeleted = [configurations objectAtIndex:indexPath.row];
     
     [configurations removeObjectAtIndex:indexPath.row];

--- a/Storyboard.storyboard
+++ b/Storyboard.storyboard
@@ -482,10 +482,58 @@
                         <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <color key="sectionIndexColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <sections>
+                            <tableViewSection headerTitle="Rom" id="lY5-xb-W8r">
+                                <cells>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="Blk-WK-fio">
+                                        <rect key="frame" x="0.0" y="114" width="1024" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Blk-WK-fio" id="cGX-Sf-bZA">
+                                            <rect key="frame" x="0.0" y="0.0" width="810" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="right" lineBreakMode="headTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sx3-I7-5YO" userLabel="RomLabel">
+                                                    <rect key="frame" x="54" y="21" width="743" height="0.0"/>
+                                                    <color key="tintColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="calibratedRGB"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ROM:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="COw-zL-jNi">
+                                                    <rect key="frame" x="13" y="11" width="43" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Requires reset to take effect" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YpF-ok-Rh9" userLabel="RequiresResetLabel">
+                                                    <rect key="frame" x="13" y="29" width="184" height="16"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
+                                                    <color key="textColor" red="0.98594832420349121" green="0.0" blue="0.026950567960739136" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="YpF-ok-Rh9" firstAttribute="leading" secondItem="cGX-Sf-bZA" secondAttribute="leadingMargin" constant="5" id="FAD-9i-hMa"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="sx3-I7-5YO" secondAttribute="trailing" constant="5" id="HSP-07-1zH"/>
+                                                <constraint firstItem="sx3-I7-5YO" firstAttribute="leading" secondItem="cGX-Sf-bZA" secondAttribute="leadingMargin" constant="46" id="Hta-E7-hfF"/>
+                                                <constraint firstItem="YpF-ok-Rh9" firstAttribute="top" secondItem="cGX-Sf-bZA" secondAttribute="topMargin" constant="21" id="W3p-F2-cCk"/>
+                                                <constraint firstAttribute="centerY" secondItem="sx3-I7-5YO" secondAttribute="centerY" id="qus-Tp-75o"/>
+                                                <constraint firstItem="COw-zL-jNi" firstAttribute="leading" secondItem="cGX-Sf-bZA" secondAttribute="leadingMargin" constant="5" id="xw2-Y9-PYA"/>
+                                                <constraint firstItem="COw-zL-jNi" firstAttribute="centerY" secondItem="cGX-Sf-bZA" secondAttribute="centerY" id="ySY-Fe-gON"/>
+                                                <constraint firstItem="YpF-ok-Rh9" firstAttribute="top" secondItem="sx3-I7-5YO" secondAttribute="bottom" constant="1" id="ybG-g5-7U3"/>
+                                            </constraints>
+                                            <variation key="default">
+                                                <mask key="constraints">
+                                                    <exclude reference="ybG-g5-7U3"/>
+                                                </mask>
+                                            </variation>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                             <tableViewSection headerTitle="Disk Drives" id="68L-YY-HYd">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="Ya0-S4-0ey">
-                                        <rect key="frame" x="0.0" y="114" width="1024" height="44"/>
+                                        <rect key="frame" x="0.0" y="201" width="1024" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Ya0-S4-0ey" id="pwu-2p-Gs1">
                                             <rect key="frame" x="0.0" y="0.0" width="810" height="43"/>
@@ -505,6 +553,7 @@
                                                 </label>
                                             </subviews>
                                             <constraints>
+                                                <constraint firstItem="Ybp-NV-rRY" firstAttribute="leading" secondItem="pwu-2p-Gs1" secondAttribute="leadingMargin" constant="5" id="A83-DL-Zcx"/>
                                                 <constraint firstItem="Ybp-NV-rRY" firstAttribute="leading" secondItem="pwu-2p-Gs1" secondAttribute="leadingMargin" constant="5" id="BIb-cw-BM0"/>
                                                 <constraint firstAttribute="centerY" secondItem="Ybp-NV-rRY" secondAttribute="centerY" constant="1" id="ckK-nK-f0z"/>
                                                 <constraint firstItem="620-hp-l7l" firstAttribute="leading" secondItem="pwu-2p-Gs1" secondAttribute="leadingMargin" constant="46" id="grp-XC-z8o"/>
@@ -514,7 +563,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="DxJ-ZI-eCV">
-                                        <rect key="frame" x="0.0" y="158" width="1024" height="44"/>
+                                        <rect key="frame" x="0.0" y="245" width="1024" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="DxJ-ZI-eCV" id="gs2-0K-ro6">
                                             <rect key="frame" x="0.0" y="0.0" width="810" height="43"/>
@@ -555,7 +604,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="g0d-v6-G6R">
-                                        <rect key="frame" x="0.0" y="202" width="1024" height="44"/>
+                                        <rect key="frame" x="0.0" y="289" width="1024" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="g0d-v6-G6R" id="j2a-ej-AUQ">
                                             <rect key="frame" x="0.0" y="0.0" width="810" height="43"/>
@@ -590,7 +639,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="zFo-pF-JH6">
-                                        <rect key="frame" x="0.0" y="246" width="1024" height="44"/>
+                                        <rect key="frame" x="0.0" y="333" width="1024" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zFo-pF-JH6" id="Fm8-9r-luR">
                                             <rect key="frame" x="0.0" y="0.0" width="810" height="43"/>
@@ -629,7 +678,7 @@
                             <tableViewSection headerTitle="Config" id="tsM-uV-vda">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="pq8-Bb-stJ">
-                                        <rect key="frame" x="0.0" y="333" width="1024" height="44"/>
+                                        <rect key="frame" x="0.0" y="420" width="1024" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="pq8-Bb-stJ" id="Mme-e3-H3P">
                                             <rect key="frame" x="0.0" y="0.0" width="1024" height="43"/>
@@ -657,7 +706,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="C9d-ZH-keI">
-                                        <rect key="frame" x="0.0" y="377" width="1024" height="44"/>
+                                        <rect key="frame" x="0.0" y="464" width="1024" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="C9d-ZH-keI" id="lGR-tj-6rS">
                                             <rect key="frame" x="0.0" y="0.0" width="810" height="43"/>
@@ -677,7 +726,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="Jkj-AM-Tp6">
-                                        <rect key="frame" x="0.0" y="421" width="1024" height="44"/>
+                                        <rect key="frame" x="0.0" y="508" width="1024" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Jkj-AM-Tp6" id="Xzu-sq-7vJ">
                                             <rect key="frame" x="0.0" y="0.0" width="810" height="43"/>
@@ -709,7 +758,7 @@
                             <tableViewSection headerTitle="Misc" id="c6N-lc-2z5">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="6nb-Q5-kfz">
-                                        <rect key="frame" x="0.0" y="508" width="1024" height="44"/>
+                                        <rect key="frame" x="0.0" y="595" width="1024" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="6nb-Q5-kfz" id="ub8-o2-ncf">
                                             <rect key="frame" x="0.0" y="0.0" width="810" height="43"/>
@@ -729,7 +778,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="Ax6-ie-wLN">
-                                        <rect key="frame" x="0.0" y="552" width="1024" height="44"/>
+                                        <rect key="frame" x="0.0" y="639" width="1024" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Ax6-ie-wLN" id="rbY-w9-W72">
                                             <rect key="frame" x="0.0" y="0.0" width="810" height="43"/>
@@ -749,7 +798,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="B1K-QU-Ck1">
-                                        <rect key="frame" x="0.0" y="596" width="1024" height="44"/>
+                                        <rect key="frame" x="0.0" y="683" width="1024" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="B1K-QU-Ck1" id="6Nk-RR-SlB">
                                             <rect key="frame" x="0.0" y="0.0" width="810" height="43"/>
@@ -779,7 +828,7 @@
                             <tableViewSection headerTitle="Hard Drives" id="rdd-8I-zRR">
                                 <cells>
                                     <tableViewCell userInteractionEnabled="NO" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="6ac-bH-HQi">
-                                        <rect key="frame" x="0.0" y="683" width="1024" height="44"/>
+                                        <rect key="frame" x="0.0" y="770" width="1024" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="6ac-bH-HQi" id="4mR-EQ-fwM">
                                             <rect key="frame" x="0.0" y="0.0" width="1024" height="43"/>
@@ -844,6 +893,8 @@
                         <outlet property="df3Switch" destination="kut-sx-3Td" id="HwV-Hh-hpZ"/>
                         <outlet property="hd0" destination="K1L-HM-ccu" id="wdX-gY-Tch"/>
                         <outlet property="hd0Switch" destination="jTX-FO-7zt" id="u9C-Vn-3yG"/>
+                        <outlet property="rom" destination="sx3-I7-5YO" id="Eng-Rg-J7h"/>
+                        <outlet property="romWarning" destination="YpF-ok-Rh9" id="07g-ig-Z8w"/>
                         <outlet property="swautoloadconfig" destination="8pu-T2-h7e" id="QNe-ue-6Qy"/>
                         <segue destination="fbF-EZ-ckx" kind="show" identifier="SelectFile" id="cfj-R0-Oey"/>
                         <segue destination="35x-lU-B56" kind="show" identifier="AssignDiskfiles" id="FAe-3z-c5O"/>
@@ -1723,7 +1774,7 @@
                                                     <rect key="frame" x="196" y="0.0" width="608" height="43"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -1743,7 +1794,7 @@
                                                     <rect key="frame" x="196" y="0.0" width="608" height="43"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -2934,8 +2985,8 @@
         <image name="sticky_unselected.png" width="25" height="25"/>
     </resources>
     <inferredMetricsTieBreakers>
+        <segue reference="cfj-R0-Oey"/>
         <segue reference="yz1-cx-vwd"/>
-        <segue reference="h8y-pV-gRq"/>
         <segue reference="mJZ-gp-RSm"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>

--- a/TargetSpecific/SingleView/SingleWindowAppDelegate.mm
+++ b/TargetSpecific/SingleView/SingleWindowAppDelegate.mm
@@ -112,16 +112,19 @@
 }
 
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
-    AdfImporter *importer = [[[AdfImporter alloc] init] autorelease];
-    BOOL imported = [importer import:url.path];
-    if (imported)
-    {
-        [SVProgressHUD setBackgroundColor:[UIColor lightGrayColor]];
-        [SVProgressHUD showSuccessWithStatus:[NSString stringWithFormat:@"Imported %@", [url.path lastPathComponent]]];
-        [[NSNotificationCenter defaultCenter] postNotificationName:[EMUROMBrowserViewController getAdfChangedNotificationName] object:nil];
+    BOOL imported = NO;
+    if ([self isAdf:url]) {
+        AdfImporter *importer = [[[AdfImporter alloc] init] autorelease];
+        imported = [importer import:url.path];
+    } else {
+        // for anything else (rom, hdf, ...?) we don't do anything special - files will be in the "Inbox" folder
+        imported = YES;
     }
-    else
-    {
+    [SVProgressHUD setBackgroundColor:[UIColor lightGrayColor]];
+    if (imported) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:[EMUROMBrowserViewController getFileImportedNotificationName] object:nil];
+        [SVProgressHUD showSuccessWithStatus:[NSString stringWithFormat:@"Imported %@", [url.path lastPathComponent]]];
+    } else {
         [SVProgressHUD showErrorWithStatus:[NSString stringWithFormat:@"Failed to import %@", [url.path lastPathComponent]]];
     }
     return imported;
@@ -129,6 +132,11 @@
 
 - (NSUInteger)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window {
     return UIInterfaceOrientationMaskLandscape;
+}
+
+- (BOOL)isAdf:(NSURL *)url {
+    NSString *extension = url.path.pathExtension.lowercaseString;
+    return [@"adf" isEqualToString:extension] || [@"zip" isEqualToString:extension];
 }
 
 - (void)dealloc {

--- a/iUAE.xcodeproj/project.pbxproj
+++ b/iUAE.xcodeproj/project.pbxproj
@@ -1269,6 +1269,8 @@
 		BE66229D1C3285B3009C2809 /* KeyButtonConfigurationController.m in Sources */ = {isa = PBXBuildFile; fileRef = BE66229C1C3285B3009C2809 /* KeyButtonConfigurationController.m */; };
 		BE6622A01C32861C009C2809 /* KeyButtonConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = BE66229F1C32861C009C2809 /* KeyButtonConfiguration.m */; };
 		BE6F9F621C4E2C420061B98C /* VPadLeftOrRight.m in Sources */ = {isa = PBXBuildFile; fileRef = BE6F9F611C4E2C420061B98C /* VPadLeftOrRight.m */; };
+		BE7631921CEAA8220007E100 /* CoreSetting.m in Sources */ = {isa = PBXBuildFile; fileRef = BE7631911CEAA8220007E100 /* CoreSetting.m */; };
+		BE7631A81CEAB0E10007E100 /* CoreSettingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BE7631A61CEAA9E40007E100 /* CoreSettingTests.m */; };
 		BE951AF21CA93EC0008DD94B /* fsusage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE951AF11CA93EC0008DD94B /* fsusage.cpp */; };
 		BE951AF41CA93F27008DD94B /* native2amiga.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE951AF31CA93F27008DD94B /* native2amiga.cpp */; };
 		BE951AF71CA93F86008DD94B /* scsi-none.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE951AF61CA93F86008DD94B /* scsi-none.cpp */; };
@@ -1293,6 +1295,16 @@
 		E937D8AA1CB58C50008DCC27 /* VPadMotionController.mm in Sources */ = {isa = PBXBuildFile; fileRef = E937D8A91CB58C50008DCC27 /* VPadMotionController.mm */; };
 		E937D8B01CB58CE3008DCC27 /* VPadTouchOrGyro.m in Sources */ = {isa = PBXBuildFile; fileRef = E937D8AF1CB58CE3008DCC27 /* VPadTouchOrGyro.m */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		BE76319C1CEAA9310007E100 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1D6058900D05DD3D006BFB54;
+			remoteInfo = iUAE;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		0504155A0FCB46F000F46828 /* EmulationViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EmulationViewController.h; sourceTree = "<group>"; };
@@ -2146,6 +2158,12 @@
 		BE66229E1C32861C009C2809 /* KeyButtonConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyButtonConfiguration.h; sourceTree = "<group>"; };
 		BE66229F1C32861C009C2809 /* KeyButtonConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KeyButtonConfiguration.m; sourceTree = "<group>"; };
 		BE6F9F611C4E2C420061B98C /* VPadLeftOrRight.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VPadLeftOrRight.m; sourceTree = "<group>"; };
+		BE7631901CEAA8220007E100 /* CoreSetting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreSetting.h; sourceTree = "<group>"; };
+		BE7631911CEAA8220007E100 /* CoreSetting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CoreSetting.m; sourceTree = "<group>"; };
+		BE7631971CEAA9310007E100 /* iUAETests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iUAETests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BE7631991CEAA9310007E100 /* iUAETests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iUAETests.m; sourceTree = "<group>"; };
+		BE76319B1CEAA9310007E100 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BE7631A61CEAA9E40007E100 /* CoreSettingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CoreSettingTests.m; path = iUAETests/CoreSettingTests.m; sourceTree = SOURCE_ROOT; };
 		BE951AF01CA93EB2008DD94B /* fsusage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = fsusage.h; path = include/fsusage.h; sourceTree = "<group>"; };
 		BE951AF11CA93EC0008DD94B /* fsusage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fsusage.cpp; sourceTree = "<group>"; };
 		BE951AF31CA93F27008DD94B /* native2amiga.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = native2amiga.cpp; sourceTree = "<group>"; };
@@ -2300,6 +2318,13 @@
 				97EF95F9153876CA001C01E6 /* CFNetwork.framework in Frameworks */,
 				97EF95FA153876CA001C01E6 /* OpenGLES.framework in Frameworks */,
 				97EF95FB153876CA001C01E6 /* QuartzCore.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BE7631941CEAA9310007E100 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2821,14 +2846,12 @@
 		05BC1B1910734C0700EABC6E /* Settings */ = {
 			isa = PBXGroup;
 			children = (
-				7E6F37771CDB4E58005BA173 /* SettingsSelectPortViewController.h */,
-				7E6F37781CDB4E58005BA173 /* SettingsSelectPortViewController.m */,
-				E937D8AE1CB58CE3008DCC27 /* VPadTouchOrGyro.h */,
-				E937D8AF1CB58CE3008DCC27 /* VPadTouchOrGyro.m */,
 				7E079CBF1A81594B00EC0DE4 /* AddConfigurationViewController.h */,
 				7E079CC01A81594B00EC0DE4 /* AddConfigurationViewController.m */,
 				BE6086D71C2CF5AC008E668B /* adfresolver.h */,
 				BE6086D81C2CF5AC008E668B /* adfresolver.mm */,
+				BE7631901CEAA8220007E100 /* CoreSetting.h */,
+				BE7631911CEAA8220007E100 /* CoreSetting.m */,
 				BE0921FD1B343D810058D9F2 /* DiskDriveService.h */,
 				BE0921FE1B343D810058D9F2 /* DiskDriveService.mm */,
 				BE52EFA91B4FC9B8008E15E6 /* DriveState.h */,
@@ -2867,6 +2890,8 @@
 				7EF076631B9B2C7A00224DF0 /* SettingsJoypadVpadController.m */,
 				7EDA12161CDB39640002B670 /* SettingsSelectKeyViewController.h */,
 				7EB0177F1B0921B000C74B9D /* SettingsSelectKeyViewController.m */,
+				7E6F37771CDB4E58005BA173 /* SettingsSelectPortViewController.h */,
+				7E6F37781CDB4E58005BA173 /* SettingsSelectPortViewController.m */,
 				7EB017771B09164900C74B9D /* State.h */,
 				7EB017761B09164900C74B9D /* State.m */,
 				7EB017741B09164900C74B9D /* StateFileManager.m */,
@@ -2875,6 +2900,8 @@
 				7EB017631B09115900C74B9D /* StateManagementController.mm */,
 				7EEFD2901BAC3DE300C7F247 /* VPadLeftOrRight.h */,
 				BE6F9F611C4E2C420061B98C /* VPadLeftOrRight.m */,
+				E937D8AE1CB58CE3008DCC27 /* VPadTouchOrGyro.h */,
+				E937D8AF1CB58CE3008DCC27 /* VPadTouchOrGyro.m */,
 			);
 			name = Settings;
 			sourceTree = "<group>";
@@ -2927,6 +2954,7 @@
 				9787FABA1561882D00458A4A /* koc.app */,
 				9787FC2215618A5E00458A4A /* sinbad.app */,
 				97C875C6156E834100197738 /* p1.app */,
+				BE7631971CEAA9310007E100 /* iUAETests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2955,9 +2983,11 @@
 				7EA4D64A1923EC9700C58BB9 /* BaseWebviewController.m */,
 				053D8B2E13B1B2C30002802F /* TargetSpecific */,
 				080E96DDFE201D6D7F000001 /* Classes */,
+				BE7631A21CEAA94C0007E100 /* TestClasses */,
 				29B97315FDCFA39411CA2CEA /* Other Sources */,
 				29B97317FDCFA39411CA2CEA /* Resources */,
 				059A411B12697B33003B23C7 /* Resources-iPad */,
+				BE7631981CEAA9310007E100 /* iUAETests */,
 				29B97323FDCFA39411CA2CEA /* Frameworks */,
 				19C28FACFE9D520D11CA2CBB /* Products */,
 			);
@@ -3918,6 +3948,32 @@
 			path = Stooges;
 			sourceTree = "<group>";
 		};
+		BE7631981CEAA9310007E100 /* iUAETests */ = {
+			isa = PBXGroup;
+			children = (
+				BE7631991CEAA9310007E100 /* iUAETests.m */,
+				BE76319B1CEAA9310007E100 /* Info.plist */,
+			);
+			path = iUAETests;
+			sourceTree = "<group>";
+		};
+		BE7631A21CEAA94C0007E100 /* TestClasses */ = {
+			isa = PBXGroup;
+			children = (
+				BE7631A31CEAA9760007E100 /* Settings */,
+			);
+			name = TestClasses;
+			path = TargetSpecific;
+			sourceTree = "<group>";
+		};
+		BE7631A31CEAA9760007E100 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				BE7631A61CEAA9E40007E100 /* CoreSettingTests.m */,
+			);
+			name = Settings;
+			sourceTree = "<group>";
+		};
 		BEE41BC91B47849F00CE487D /* minizip */ = {
 			isa = PBXGroup;
 			children = (
@@ -4075,6 +4131,24 @@
 			productReference = 97EF9600153876CA001C01E6 /* stooges.app */;
 			productType = "com.apple.product-type.application";
 		};
+		BE7631961CEAA9310007E100 /* iUAETests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BE76319E1CEAA9310007E100 /* Build configuration list for PBXNativeTarget "iUAETests" */;
+			buildPhases = (
+				BE7631931CEAA9310007E100 /* Sources */,
+				BE7631941CEAA9310007E100 /* Frameworks */,
+				BE7631951CEAA9310007E100 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BE76319D1CEAA9310007E100 /* PBXTargetDependency */,
+			);
+			name = iUAETests;
+			productName = iUAETests;
+			productReference = BE7631971CEAA9310007E100 /* iUAETests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -4085,6 +4159,10 @@
 				TargetAttributes = {
 					1D6058900D05DD3D006BFB54 = {
 						DevelopmentTeam = 6854WVMAT3;
+					};
+					BE7631961CEAA9310007E100 = {
+						CreatedOnToolsVersion = 7.3;
+						TestTargetID = 1D6058900D05DD3D006BFB54;
 					};
 				};
 			};
@@ -4107,6 +4185,7 @@
 				9787F9FF1561882D00458A4A /* koc */,
 				9787FB6115618A5E00458A4A /* sinbad */,
 				97C87500156E834100197738 /* 3s2 */,
+				BE7631961CEAA9310007E100 /* iUAETests */,
 			);
 		};
 /* End PBXProject section */
@@ -4740,6 +4819,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BE7631951CEAA9310007E100 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
@@ -4985,6 +5071,7 @@
 				7E3C13E51A51F16600534164 /* SettingsGeneralController.mm in Sources */,
 				97855127153A3F2E00580B91 /* TexturedCRTEffect.m in Sources */,
 				9785512A153A3F2E00580B91 /* SDL_UIKitEvents.m in Sources */,
+				BE7631921CEAA8220007E100 /* CoreSetting.m in Sources */,
 				9785512D153A3F2E00580B91 /* SDL_UIKitVideo.m in Sources */,
 				BE951AF21CA93EC0008DD94B /* fsusage.cpp in Sources */,
 			);
@@ -5482,7 +5569,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BE7631931CEAA9310007E100 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BE7631A81CEAB0E10007E100 /* CoreSettingTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		BE76319D1CEAA9310007E100 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1D6058900D05DD3D006BFB54 /* iUAE */;
+			targetProxy = BE76319C1CEAA9310007E100 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		0533694E13B1DEE90012D55A /* Debug */ = {
@@ -5954,6 +6057,133 @@
 			};
 			name = "Ad Hoc";
 		};
+		BE76319F1CEAA9310007E100 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = iUAETests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = mh_bundle;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = ursschhmid.iUAETests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iUAE.app/iUAE";
+			};
+			name = Debug;
+		};
+		BE7631A01CEAA9310007E100 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = iUAETests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = mh_bundle;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = ursschhmid.iUAETests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iUAE.app/iUAE";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		BE7631A11CEAA9310007E100 /* Ad Hoc */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = iUAETests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = mh_bundle;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = ursschhmid.iUAETests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iUAE.app/iUAE";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "Ad Hoc";
+		};
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -6142,6 +6372,15 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		BE76319E1CEAA9310007E100 /* Build configuration list for PBXNativeTarget "iUAETests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BE76319F1CEAA9310007E100 /* Debug */,
+				BE7631A01CEAA9310007E100 /* Release */,
+				BE7631A11CEAA9310007E100 /* Ad Hoc */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 		C01FCF4E08A954540054247B /* Build configuration list for PBXProject "iUAE" */ = {
 			isa = XCConfigurationList;

--- a/iUAEParents/Settings.h
+++ b/iUAEParents/Settings.h
@@ -33,6 +33,7 @@ static NSString *const kJoyStyleFourButton = @"FourButton";
 @property (nonatomic, readwrite, assign) BOOL showStatusBar;
 @property (nonatomic, readwrite, assign) NSUInteger selectedEffectIndex;
 @property (nonatomic, readwrite, assign) DriveState *driveState;
+@property (nonatomic, readwrite, assign) NSString *romPath;
 @property (nonatomic, readwrite, assign) NSString *hardfilePath;
 @property (nonatomic, readwrite, assign) NSString *joypadstyle;
 @property (nonatomic, readwrite, assign) NSString *joypadleftorright;
@@ -47,7 +48,6 @@ static NSString *const kJoyStyleFourButton = @"FourButton";
 @property (nonatomic, readwrite, assign) NSUInteger controllersnextid;
 @property (nonatomic, readwrite, assign) NSArray *controllers;
 @property (nonatomic, readwrite, assign) NSInteger keyConfigurationCount;
-
 
 - (void)setFloppyConfigurations:(NSArray *)adfPaths;
 - (void)setFloppyConfiguration:(NSString *)adfPath;

--- a/iUAEParents/Settings.mm
+++ b/iUAEParents/Settings.mm
@@ -56,6 +56,7 @@ static NSString *const kDPadTouchOrMotion = @"_dpadTouchOrMotion";
 static NSString *const kGyroToggleUpDown = @"_gyroToggleUpDown";
 static NSString *const kGyroSensitivity = @"_gyroSensitivity";
 
+static NSString *const kRomPath = @"romPath";
 static NSString *const kDf1EnabledKey = @"df1Enabled";
 static NSString *const kDf2EnabledKey = @"df2Enabled";
 static NSString *const kDf3EnabledKey = @"df3Enabled";
@@ -396,6 +397,13 @@ static int _cNumber = 1;
     [self setObject:controllers forKey:kControllersKey];
 }
 
+- (NSString *)romPath {
+    return [self stringForKey:kRomPath];
+}
+
+- (void)setRomPath:(NSString *)romPath {
+    [self setObject:romPath forKey:kRomPath];
+}
 
 - (DriveState *)driveState {
     DriveState *driveState = [[[DriveState alloc] init] autorelease];

--- a/iUAETests/CoreSettingTests.m
+++ b/iUAETests/CoreSettingTests.m
@@ -1,0 +1,83 @@
+//  Created by Simon Toens on 11.05.16
+//
+//  iUAE is free software: you may copy, redistribute
+//  and/or modify it under the terms of the GNU General Public License as
+//  published by the Free Software Foundation, either version 2 of the
+//  License, or (at your option) any later version.
+//
+//  This file is distributed in the hope that it will be useful, but
+//  WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+#import <XCTest/XCTest.h>
+#import "CoreSetting.h"
+
+@interface CoreSettingTests : XCTestCase
+
+@end
+
+@implementation CoreSettingTests
+
+- (void)tearDown {
+    [CoreSettings onReset];
+    [super tearDown];
+}
+
+- (void)testRomSettingSingleton {
+    RomCoreSetting *rom1 = [CoreSettings romCoreSetting];
+    RomCoreSetting *rom2 = [CoreSettings romCoreSetting];
+    
+    XCTAssertNotNil(rom1);
+    XCTAssertTrue(rom1 == rom2);
+}
+
+- (void)testHasUnappliedValue {
+    XCTAssertFalse([[CoreSettings romCoreSetting] hasUnappliedValue]);
+    [[CoreSettings romCoreSetting] toggleFromOldValue:@"v1" toNewValue:@"v2"];
+    XCTAssertTrue([[CoreSettings romCoreSetting] hasUnappliedValue]);
+}
+
+- (void)testHasUnappliedValue_backToOriginalValue {
+    XCTAssertFalse([[CoreSettings romCoreSetting] hasUnappliedValue]);
+    [[CoreSettings romCoreSetting] toggleFromOldValue:@"v1" toNewValue:@"v2"];
+    XCTAssertTrue([[CoreSettings romCoreSetting] hasUnappliedValue]);
+    
+    [[CoreSettings romCoreSetting] toggleFromOldValue:@"v2" toNewValue:@"v3"];
+    XCTAssertTrue([[CoreSettings romCoreSetting] hasUnappliedValue]);
+    
+    [[CoreSettings romCoreSetting] toggleFromOldValue:@"v3" toNewValue:@"v1"];
+    XCTAssertFalse([[CoreSettings romCoreSetting] hasUnappliedValue]);
+}
+
+- (void)testToggleSameValue {
+    [[CoreSettings romCoreSetting] toggleFromOldValue:@"v101" toNewValue:@"v101"];
+    XCTAssertFalse([[CoreSettings romCoreSetting] hasUnappliedValue]);
+}
+
+- (void)testToggleSameValue_nils {
+    [[CoreSettings romCoreSetting] toggleFromOldValue:nil toNewValue:nil];
+    XCTAssertFalse([[CoreSettings romCoreSetting] hasUnappliedValue]);
+}
+
+- (void)testOldValueIsNil {
+    [[CoreSettings romCoreSetting] toggleFromOldValue:nil toNewValue:@"new"];
+    XCTAssertTrue([[CoreSettings romCoreSetting] hasUnappliedValue]);
+    
+    [[CoreSettings romCoreSetting] toggleFromOldValue:@"new" toNewValue:nil];
+    XCTAssertFalse([[CoreSettings romCoreSetting] hasUnappliedValue]);
+}
+
+- (void)testNewValueIsNil {
+    [[CoreSettings romCoreSetting] toggleFromOldValue:@"old" toNewValue:nil];
+    XCTAssertTrue([[CoreSettings romCoreSetting] hasUnappliedValue]);
+    
+    [[CoreSettings romCoreSetting] toggleFromOldValue:nil toNewValue:@"old"];
+    XCTAssertFalse([[CoreSettings romCoreSetting] hasUnappliedValue]);
+}
+
+@end

--- a/iUAETests/Info.plist
+++ b/iUAETests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/uae4all_gp2x_0.7.2a/src/include/memory.h
+++ b/uae4all_gp2x_0.7.2a/src/include/memory.h
@@ -68,6 +68,9 @@ extern uae_u32 allocated_a3000mem;
 extern int ersatzkickfile;
 extern int cloanto_rom;
 
+extern int bReloadKickstart;
+
+
 extern uae_u8* baseaddr[];
 
 typedef struct {


### PR DESCRIPTION
… use

This change adds the ability to pick a rom at emulation run time;
previously the rom selection was based on rom file names, and hardcoded.

The commit also adds a unit test target and the first unit test suite.

Additional changes include:
- Add model for keeping track of settings that require the emulator
  to be reset to take effect
- "Sharing" now enabled for additional file types: .rom and .hdf
- "Fix sharing bugs: was crashing on iPad and was not enabled for all adfs
- Update rom info in README
