### PR TITLE
Update iCadeReaderView.mm

### DIFF
--- a/libraries/sdl-mini/src/joystick/iOS/iCadeReaderView.mm
+++ b/libraries/sdl-mini/src/joystick/iOS/iCadeReaderView.mm
@@ -222,7 +222,7 @@ static const char *OFF_STATES = "eczqtrfnmpgv";
     
     int tiState = (int) _iCadeState;
     
-    char *p = strchr(ON_STATES, ch);
+    const char *p = strchr(ON_STATES, ch);
     bool stateChanged = false;
     if (p) {
         int index = p-ON_STATES;


### PR DESCRIPTION
On XCode 9 it did not compile, as it complains about assignment from "const char*" co "char*". Fixed it in the code.  The code creates still many warnings, but at least compiles and runs with XCode 9.