### PR TITLE
Fix compiler error

### DIFF
--- a/libraries/sdl-mini/src/joystick/iOS/iCadeReaderView.mm
+++ b/libraries/sdl-mini/src/joystick/iOS/iCadeReaderView.mm
@@ -222,7 +222,7 @@ static const char *OFF_STATES = "eczqtrfnmpgv";
     
     int tiState = (int) _iCadeState;
     
-    char *p = strchr(ON_STATES, ch);
+    const char *p = strchr(ON_STATES, ch);
     bool stateChanged = false;
     if (p) {
         int index = p-ON_STATES;


### PR DESCRIPTION
The latest Xcode fails to compile without this variable being declared as a `const`